### PR TITLE
Profile Management Admin Backend

### DIFF
--- a/client/src/components/volunteerManagement/VolunteerList.tsx
+++ b/client/src/components/volunteerManagement/VolunteerList.tsx
@@ -13,18 +13,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useBackendContext } from "@/contexts/hooks/useBackendContext";
-
-export type Volunteer = {
-  id: number;
-  firstName: string;
-  lastName: string;
-  email: string;
-  phoneNumber?: string;
-  role?: string;
-  specializations?: string[];
-  languages?: string[];
-  experienceLevel?: string;
-};
+import { Volunteer } from "@/types/volunteer";
 
 interface VolunteerListProps {
   variant?: "list" | "table";

--- a/client/src/components/volunteerManagement/VolunteerList.tsx
+++ b/client/src/components/volunteerManagement/VolunteerList.tsx
@@ -23,6 +23,7 @@ export type Volunteer = {
   role?: string;
   specializations?: string[];
   languages?: string[];
+  experienceLevel?: string;
 };
 
 interface VolunteerListProps {

--- a/client/src/components/volunteerManagement/VolunteerList.tsx
+++ b/client/src/components/volunteerManagement/VolunteerList.tsx
@@ -29,12 +29,14 @@ interface VolunteerListProps {
   variant?: "list" | "table";
   onSelect?: (volunteer: Volunteer) => void;
   selectedId?: number;
+  refreshId?: number;
 }
 
 export const VolunteerList = ({
   variant = "list",
   onSelect,
   selectedId,
+  refreshId = 0,
 }: VolunteerListProps) => {
   const [volunteers, setVolunteers] = useState<Volunteer[]>([]);
   const { backend } = useBackendContext();
@@ -44,16 +46,20 @@ export const VolunteerList = ({
       const res = await backend.get<Volunteer[]>("/volunteers");
       setVolunteers(res.data);
     })();
-  }, [backend]);
+  }, [backend, refreshId]);
+
+  const handleDelete = async (e: React.MouseEvent, volunteerId: number) => {
+    e.stopPropagation();
+
+    await backend.delete(`/volunteers/${volunteerId}`);
+
+    setVolunteers((prev) => prev.filter((v) => v.id !== volunteerId));
+  };
 
   return (
     <Box>
       {variant === "list" && (
-        <Box
-          mt={4}
-          borderWidth="1px"
-          borderColor="gray.200"
-        >
+        <Box mt={4} borderWidth="1px" borderColor="gray.200">
           <Table size="md">
             <Thead>
               <Tr>
@@ -81,16 +87,10 @@ export const VolunteerList = ({
                         borderRadius="full"
                         mr={3}
                       />
-                      <Text
-                        fontSize="sm"
-                        flex="1"
-                      >
+                      <Text fontSize="sm" flex="1">
                         {volunteer.firstName} {volunteer.lastName}
                       </Text>
-                      <Text
-                        fontSize="sm"
-                        color="gray.700"
-                      >
+                      <Text fontSize="sm" color="gray.700">
                         Volunteer
                       </Text>
                     </Flex>
@@ -103,11 +103,7 @@ export const VolunteerList = ({
       )}
 
       {variant === "table" && (
-        <Box
-          mt={4}
-          borderWidth="1px"
-          borderColor="gray.200"
-        >
+        <Box mt={4} borderWidth="1px" borderColor="gray.200">
           <Table size="md">
             <Thead>
               <Tr>
@@ -130,10 +126,7 @@ export const VolunteerList = ({
                   }}
                 >
                   <Td>
-                    <Flex
-                      align="center"
-                      gap={3}
-                    >
+                    <Flex align="center" gap={3}>
                       <Box
                         w="24px"
                         h="24px"
@@ -152,6 +145,8 @@ export const VolunteerList = ({
                   <Td
                     textAlign="right"
                     fontSize="18px"
+                    onClick={(e) => handleDelete(e, volunteer.id)}
+                    _hover={{ opacity: 0.7, cursor: "pointer" }}
                   >
                     🗑️
                   </Td>

--- a/client/src/components/volunteerManagement/VolunteerList.tsx
+++ b/client/src/components/volunteerManagement/VolunteerList.tsx
@@ -43,12 +43,7 @@ export const VolunteerList = ({
     (async () => {
       const res = await backend.get<Volunteer[]>("/volunteers");
       setVolunteers(res.data);
-      const firstVolunteer = res.data[0];
-      if (firstVolunteer && !selectedId && onSelect) {
-        onSelect(firstVolunteer);
-      }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend]);
 
   return (

--- a/client/src/components/volunteerManagement/VolunteerList.tsx
+++ b/client/src/components/volunteerManagement/VolunteerList.tsx
@@ -14,20 +14,28 @@ import {
 
 import { useBackendContext } from "@/contexts/hooks/useBackendContext";
 
-interface VolunteerProfilesPanelProps {
+export type Volunteer = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber?: string;
+  role?: string;
+  specializations?: string[];
+  languages?: string[];
+};
+
+interface VolunteerListProps {
   variant?: "list" | "table";
+  onSelect?: (volunteer: Volunteer) => void;
+  selectedId?: number;
 }
 
-export const VolunteerProfilesPanel = ({
+export const VolunteerList = ({
   variant = "list",
-}: VolunteerProfilesPanelProps) => {
-  type Volunteer = {
-    id: number;
-    firstName: string;
-    lastName: string;
-    email: string;
-  };
-
+  onSelect,
+  selectedId,
+}: VolunteerListProps) => {
   const [volunteers, setVolunteers] = useState<Volunteer[]>([]);
   const { backend } = useBackendContext();
 
@@ -35,7 +43,12 @@ export const VolunteerProfilesPanel = ({
     (async () => {
       const res = await backend.get<Volunteer[]>("/volunteers");
       setVolunteers(res.data);
+      const firstVolunteer = res.data[0];
+      if (firstVolunteer && !selectedId && onSelect) {
+        onSelect(firstVolunteer);
+      }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend]);
 
   return (
@@ -54,7 +67,15 @@ export const VolunteerProfilesPanel = ({
             </Thead>
             <Tbody>
               {volunteers.map((volunteer) => (
-                <Tr key={volunteer.id}>
+                <Tr
+                  key={volunteer.id}
+                  onClick={() => onSelect?.(volunteer)}
+                  bg={selectedId === volunteer.id ? "blue.50" : undefined}
+                  _hover={{
+                    bg: selectedId === volunteer.id ? "blue.100" : "gray.50",
+                    cursor: "pointer",
+                  }}
+                >
                   <Td>
                     <Flex align="center">
                       <Box
@@ -104,7 +125,15 @@ export const VolunteerProfilesPanel = ({
             </Thead>
             <Tbody>
               {volunteers.map((volunteer) => (
-                <Tr key={volunteer.id}>
+                <Tr
+                  key={volunteer.id}
+                  onClick={() => onSelect?.(volunteer)}
+                  bg={selectedId === volunteer.id ? "blue.50" : undefined}
+                  _hover={{
+                    bg: selectedId === volunteer.id ? "blue.100" : "gray.50",
+                    cursor: "pointer",
+                  }}
+                >
                   <Td>
                     <Flex
                       align="center"

--- a/client/src/components/volunteerManagement/VolunteerManagementView.tsx
+++ b/client/src/components/volunteerManagement/VolunteerManagementView.tsx
@@ -3,19 +3,18 @@ import { useState } from "react";
 import {
   Box,
   Button,
-  ButtonGroup,
   Flex,
   Heading,
   Input,
 } from "@chakra-ui/react";
 
-import { VolunteerProfilePanel } from "./VolunteerProfilePanel";
 import { VolunteerList, type Volunteer } from "./VolunteerList";
+import { VolunteerProfilePanel } from "./VolunteerProfilePanel";
 
-type ViewMode = "list" | "split" | "profile";
+type ViewMode = "list" | "split";
 
 export const VolunteerManagementView = () => {
-  const [viewMode, setViewMode] = useState<ViewMode>("split");
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [isAdding, setIsAdding] = useState(false);
   const [selectedVolunteer, setSelectedVolunteer] = useState<Volunteer | null>(
     null
@@ -33,113 +32,87 @@ export const VolunteerManagementView = () => {
       p={4}
       h="100%"
     >
-      <Box mb={4}>
-        <ButtonGroup
-          size="sm"
-          isAttached
-          variant="outline"
+      <>
+        <Heading
+          size="md"
+          mb={2}
         >
-          <Button
-            onClick={() => setViewMode("list")}
-            colorScheme={viewMode === "list" ? "blue" : undefined}
-          >
-            List Only
-          </Button>
-          <Button
-            onClick={() => setViewMode("split")}
-            colorScheme={viewMode === "split" ? "blue" : undefined}
-          >
-            Split View
-          </Button>
-          <Button
-            onClick={() => setViewMode("profile")}
-            colorScheme={viewMode === "profile" ? "blue" : undefined}
-          >
-            Profile Only
-          </Button>
-        </ButtonGroup>
-      </Box>
-
-      {viewMode !== "profile" && (
-        <>
-          <Heading
-            size="md"
-            mb={2}
-          >
-            Profile List
-          </Heading>
+          Profile List
+        </Heading>
+        <Flex
+          gap={2}
+          align="center"
+          mb={4}
+        >
           <Flex
-            gap={2}
             align="center"
-            mb={4}
+            borderWidth="1px"
+            borderColor="gray.300"
+            borderRadius="md"
+            px={2}
+            w="100%"
+            h="40px"
           >
-            <Flex
-              align="center"
+            <Box
+              w="14px"
+              h="14px"
               borderWidth="1px"
-              borderColor="gray.300"
-              borderRadius="md"
-              px={2}
-              w="100%"
-              h="40px"
-            >
-              <Box
-                w="14px"
-                h="14px"
-                borderWidth="1px"
-                borderColor="gray.600"
-                borderRadius="sm"
-                mr={2}
-              />
-              <Input
-                variant="unstyled"
-                placeholder=""
-                fontSize="sm"
-              />
-            </Flex>
-            <Button
-              size="sm"
-              variant="outline"
-            >
-              Filters
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleAddClick}
-            >
-              Add Profile
-            </Button>
+              borderColor="gray.600"
+              borderRadius="sm"
+              mr={2}
+            />
+            <Input
+              variant="unstyled"
+              placeholder=""
+              fontSize="sm"
+            />
           </Flex>
-        </>
-      )}
+          <Button
+            size="sm"
+            variant="outline"
+          >
+            Filters
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleAddClick}
+          >
+            Add Profile
+          </Button>
+        </Flex>
+      </>
 
       <Flex
         h="calc(100vh - 140px)"
         gap={6}
       >
-        {(viewMode === "list" || viewMode === "split") && (
-          <Box
-            w={viewMode === "split" ? "30%" : "100%"}
-            minW={viewMode === "split" ? "300px" : undefined}
-            h="100%"
-            overflowY="auto"
-          >
-            <VolunteerList
-              variant={viewMode === "list" ? "table" : "list"}
-              onSelect={setSelectedVolunteer}
-              selectedId={selectedVolunteer?.id}
-            />
-          </Box>
-        )}
+        <Box
+          w={viewMode === "split" ? "30%" : "100%"}
+          minW={viewMode === "split" ? "300px" : undefined}
+          h="100%"
+          overflowY="auto"
+        >
+          <VolunteerList
+            variant={viewMode === "list" ? "table" : "list"}
+            onSelect={(volunteer) => {
+              setSelectedVolunteer(volunteer);
+              if (viewMode === "list") {
+                setViewMode("split");
+              }
+            }}
+            selectedId={selectedVolunteer?.id}
+          />
+        </Box>
 
-        {(viewMode === "profile" || viewMode === "split") && (
+        {viewMode === "split" && (
           <Box
-            w={viewMode === "split" ? "70%" : "100%"}
+            w="70%"
             h="100%"
             overflowY="auto"
-            borderLeftWidth={viewMode === "split" ? "1px" : "0px"}
+            borderLeftWidth="1px"
             borderLeftColor="gray.200"
-            pl={viewMode === "split" ? 6 : 0}
+            pl={6}
           >
             {isAdding ? (
               <VolunteerProfilePanel
@@ -153,7 +126,7 @@ export const VolunteerManagementView = () => {
               />
             ) : (
               <VolunteerProfilePanel
-                showBack={viewMode === "profile"}
+                showBack
                 onBack={() => setViewMode("list")}
                 volunteer={selectedVolunteer}
               />

--- a/client/src/components/volunteerManagement/VolunteerManagementView.tsx
+++ b/client/src/components/volunteerManagement/VolunteerManagementView.tsx
@@ -127,7 +127,7 @@ export const VolunteerManagementView = () => {
                       email: data.email,
                       phone_number: data.phoneNumber,
                       role: data.role,
-                      experience_level: "advanced", //data.experienceLevel
+                      experience_level: data.experienceLevel,
                     };
 
                     const res = await backend.backend.post("/volunteers", payload);
@@ -156,7 +156,7 @@ export const VolunteerManagementView = () => {
                       email: data.email,
                       phone_number: data.phoneNumber,
                       role: data.role,
-                      experience_level: "advanced", //data.experienceLevel
+                      experience_level: data.experienceLevel,
                     }
                   );
 

--- a/client/src/components/volunteerManagement/VolunteerManagementView.tsx
+++ b/client/src/components/volunteerManagement/VolunteerManagementView.tsx
@@ -10,13 +10,16 @@ import {
 } from "@chakra-ui/react";
 
 import { VolunteerProfilePanel } from "./VolunteerProfilePanel";
-import { VolunteerProfilesPanel } from "./VolunteerProfilesPanel";
+import { VolunteerList, type Volunteer } from "./VolunteerList";
 
 type ViewMode = "list" | "split" | "profile";
 
 export const VolunteerManagementView = () => {
   const [viewMode, setViewMode] = useState<ViewMode>("split");
   const [isAdding, setIsAdding] = useState(false);
+  const [selectedVolunteer, setSelectedVolunteer] = useState<Volunteer | null>(
+    null
+  );
 
   const handleAddClick = () => {
     setIsAdding(true);
@@ -121,8 +124,10 @@ export const VolunteerManagementView = () => {
             h="100%"
             overflowY="auto"
           >
-            <VolunteerProfilesPanel
+            <VolunteerList
               variant={viewMode === "list" ? "table" : "list"}
+              onSelect={setSelectedVolunteer}
+              selectedId={selectedVolunteer?.id}
             />
           </Box>
         )}
@@ -150,6 +155,7 @@ export const VolunteerManagementView = () => {
               <VolunteerProfilePanel
                 showBack={viewMode === "profile"}
                 onBack={() => setViewMode("list")}
+                volunteer={selectedVolunteer}
               />
             )}
           </Box>

--- a/client/src/components/volunteerManagement/VolunteerManagementView.tsx
+++ b/client/src/components/volunteerManagement/VolunteerManagementView.tsx
@@ -3,8 +3,9 @@ import { useState } from "react";
 import { Box, Button, Flex, Heading, Input } from "@chakra-ui/react";
 
 import { useBackendContext } from "@/contexts/hooks/useBackendContext";
+import { Volunteer } from "@/types/volunteer";
 
-import { VolunteerList, type Volunteer } from "./VolunteerList";
+import { VolunteerList } from "./VolunteerList";
 import { VolunteerProfilePanel } from "./VolunteerProfilePanel";
 
 type ViewMode = "list" | "split";
@@ -121,7 +122,7 @@ export const VolunteerManagementView = () => {
                 onConfirm={async (data) => {
                   try {
                     const payload = {
-                      firebaseUid: "placeholder-uid6", // TODO: generate dynamically
+                      firebaseUid: "placeholder-uid7", // TODO: generate dynamically
                       first_name: data.firstName,
                       last_name: data.lastName,
                       email: data.email,
@@ -134,7 +135,17 @@ export const VolunteerManagementView = () => {
 
                     setIsAdding(false);
                     setRefreshTrigger((prev) => prev + 1);
-                    setSelectedVolunteer(res.data);
+
+                    // Map snake_case response to camelCase for frontend
+                    const newVolunteer = {
+                      ...res.data,
+                      firstName: res.data.first_name || data.firstName,
+                      lastName: res.data.last_name || data.lastName,
+                      phoneNumber: res.data.phone_number || data.phoneNumber,
+                      experienceLevel: res.data.experience_level || data.experienceLevel,
+                    };
+
+                    setSelectedVolunteer(newVolunteer);
                   } catch (error) {
                     console.error("Error creating volunteer:", error);
                   }

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -14,7 +14,7 @@ import {
 
 import { useForm, UseFormRegisterReturn } from "react-hook-form";
 
-import { Volunteer } from "./VolunteerList";
+import { Volunteer } from "@/types/volunteer";
 
 interface LabeledBoxProps {
   label: string;

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -9,6 +9,8 @@ import {
   Select,
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
+import { useEffect } from "react";
+import { Volunteer } from "./VolunteerList";
 
 interface LabeledBoxProps {
   label: string;
@@ -56,20 +58,50 @@ interface VolunteerProfilePanelProps {
   showBack?: boolean;
   onBack?: () => void;
   onConfirm?: (data: VolunteerProfileFormData) => void;
+  volunteer?: Volunteer | null;
 }
 
-export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, onConfirm }: VolunteerProfilePanelProps) => {
+export const VolunteerProfilePanel = ({
+  variant = "profile",
+  showBack,
+  onBack,
+  onConfirm,
+  volunteer,
+}: VolunteerProfilePanelProps) => {
   const isNew = variant === "new";
-  const { register, handleSubmit } = useForm<VolunteerProfileFormData>();
+  const { register, handleSubmit, reset } = useForm<VolunteerProfileFormData>();
+
+  useEffect(() => {
+    if (volunteer) {
+      reset({
+        firstName: volunteer.firstName,
+        lastName: volunteer.lastName,
+        email: volunteer.email,
+        phoneNumber: volunteer.phoneNumber || "",
+        role: volunteer.role || "volunteer",
+      });
+    }
+  }, [volunteer, reset]);
 
   const onSubmit = (data: VolunteerProfileFormData) => {
     if (onConfirm) onConfirm(data);
   };
 
+  if (!isNew && !volunteer) {
+    return (
+      <Box p={6}>
+        <Text>Please select a volunteer from the list.</Text>
+      </Box>
+    );
+  }
+
   return (
     <Box>
       {/* Header row */}
-      <Flex align="center" mb={4}>
+      <Flex
+        align="center"
+        mb={4}
+      >
         {showBack && (
           <Box
             as="button"
@@ -82,7 +114,9 @@ export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, o
         )}
 
         <Heading size="md">
-          {isNew ? "New Profile" : "[Volunteer Name] Profile"}
+          {isNew
+            ? "New Profile"
+            : `${volunteer?.firstName} ${volunteer?.lastName}`}
         </Heading>
 
         <Box flex="1" />
@@ -131,14 +165,23 @@ export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, o
                 />
               </>
             ) : (
-              <LabeledBox label="First Name" value="Peter" />
+              <LabeledBox
+                label="First Name"
+                value={volunteer?.firstName || ""}
+              />
             )}
           </Box>
 
           <Box w={isNew ? "160px" : "100%"}>
             {isNew ? (
               <>
-                <Text fontSize="xs" fontWeight="700" mb={1}>Last Name</Text>
+                <Text
+                  fontSize="xs"
+                  fontWeight="700"
+                  mb={1}
+                >
+                  Last Name
+                </Text>
                 <Input
                   h="34px"
                   fontSize="xs"
@@ -149,7 +192,10 @@ export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, o
                 />
               </>
             ) : (
-              <LabeledBox label="Last Name" value="Anteater" />
+              <LabeledBox
+                label="Last Name"
+                value={volunteer?.lastName || ""}
+              />
             )}
           </Box>
           
@@ -186,14 +232,23 @@ export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, o
                  />
                </>
              ) : (
-               <LabeledBox label="Email Address" value="peteranteater@uci.edu" />
+               <LabeledBox
+                 label="Email Address"
+                 value={volunteer?.email || ""}
+               />
              )}
           </Box>
 
           <Box w={isNew ? "160px" : "100%"}>
              {isNew ? (
                <>
-                 <Text fontSize="xs" fontWeight="700" mb={1}>Phone Number</Text>
+                 <Text
+                   fontSize="xs"
+                   fontWeight="700"
+                   mb={1}
+                 >
+                   Phone Number
+                 </Text>
                  <Input
                     h="34px"
                     fontSize="xs"
@@ -204,17 +259,27 @@ export const VolunteerProfilePanel = ({ variant = "profile", showBack, onBack, o
                  />
                </>
              ) : (
-               <LabeledBox label="Phone Number" value="621-438-3991" />
+               <LabeledBox
+                 label="Phone Number"
+                 value={volunteer?.phoneNumber || ""}
+               />
              )}
           </Box>
 
           {!isNew && (
             <>
               <Box w="120px">
-                <LabeledBox label="Birthday" value="02/14/1999" dropdown />
+                <LabeledBox
+                  label="Birthday"
+                  value=""
+                  dropdown
+                />
               </Box>
               <Box w="120px">
-                <LabeledBox label="Role" value="Volunteer" />
+                <LabeledBox
+                  label="Role"
+                  value={volunteer?.role || "Volunteer"}
+                />
               </Box>
             </>
           )}

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -8,8 +8,8 @@ import {
   Input,
   Select,
 } from "@chakra-ui/react";
-import { useForm } from "react-hook-form";
-import { useEffect } from "react";
+import { useForm, UseFormRegisterReturn } from "react-hook-form";
+import { useEffect, useState } from "react";
 import { Volunteer } from "./VolunteerList";
 import { ChevronLeftIcon } from '@chakra-ui/icons'
 
@@ -54,6 +54,54 @@ function LabeledBox({ label, width = "100%", value, dropdown = false }: Readonly
   );
 }
 
+interface ProfileFieldProps {
+  label: string;
+  isEditing: boolean;
+  registerProps?: UseFormRegisterReturn;
+  value?: string;
+  width?: string;
+  type?: "text" | "select";
+  options?: { value: string; label: string }[];
+}
+
+const ProfileField = ({ label, isEditing, registerProps, value, width = "100%", type = "text", options }: ProfileFieldProps) => {
+  return (
+    <Box w={width}>
+      {isEditing ? (
+        <>
+          <Text fontSize="xs" fontWeight="700" mb={1}>
+            {label}
+          </Text>
+          {type === 'select' ? (
+             <Select
+                  h="34px"
+                  fontSize="xs"
+                  bg="white"
+                  borderRadius="sm"
+                  borderColor="gray.500"
+                  iconColor="black"
+                  {...registerProps}
+                >
+                  {options?.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+             </Select>
+          ) : (
+            <Input
+              h="34px"
+              fontSize="xs"
+              bg="white"
+              borderRadius="sm"
+              borderColor="gray.500"
+              {...registerProps}
+            />
+          )}
+        </>
+      ) : (
+        <LabeledBox label={label} value={value || ""} />
+      )}
+    </Box>
+  );
+};
+
 interface VolunteerProfilePanelProps {
   variant?: string;
   showBack?: boolean;
@@ -70,6 +118,7 @@ export const VolunteerProfilePanel = ({
   volunteer,
 }: VolunteerProfilePanelProps) => {
   const isNew = variant === "new";
+  const [isEditing, setIsEditing] = useState(false);
   const { register, handleSubmit, reset } = useForm<VolunteerProfileFormData>();
 
   useEffect(() => {
@@ -86,6 +135,7 @@ export const VolunteerProfilePanel = ({
 
   const onSubmit = (data: VolunteerProfileFormData) => {
     if (onConfirm) onConfirm(data);
+    if (!isNew) setIsEditing(false);
   };
 
   if (!isNew && !volunteer) {
@@ -125,8 +175,8 @@ export const VolunteerProfilePanel = ({
 
         <Box flex="1" />
 
-        {!isNew && (
-          <Button size="xs" variant="outline">
+        {!isNew && !isEditing && (
+          <Button size="xs" variant="outline" onClick={() => setIsEditing(true)}>
             Edit ↗
           </Button>
         )}
@@ -146,7 +196,7 @@ export const VolunteerProfilePanel = ({
       )}
 
       {/* Main form container */}
-      <Box bg="gray.50" borderWidth="0px" p={6} as="form" onSubmit={isNew ? handleSubmit(onSubmit) : undefined}>
+      <Box bg="gray.50" borderWidth="0px" p={6} as="form" onSubmit={(isNew || isEditing) ? handleSubmit(onSubmit) : undefined}>
         {!isNew && (
           <Heading size="sm" mb={4}>
             Background Information
@@ -155,53 +205,21 @@ export const VolunteerProfilePanel = ({
 
         {/* Profile or New Profile fields */}
         <SimpleGrid columns={isNew ? 3 : 2} spacing={6} maxW={isNew ? "720px" : "760px"}>
-          <Box w={isNew ? "160px" : "100%"}>
-            {isNew ? (
-              <>
-                <Text fontSize="xs" fontWeight="700" mb={1}>First Name</Text>
-                <Input
-                  h="34px"
-                  fontSize="xs"
-                  bg="white"
-                  borderRadius="sm"
-                  borderColor="gray.500"
-                  {...register("firstName")}
-                />
-              </>
-            ) : (
-              <LabeledBox
-                label="First Name"
-                value={volunteer?.firstName || ""}
-              />
-            )}
-          </Box>
+          <ProfileField
+            label="First Name"
+            isEditing={isNew || isEditing}
+            registerProps={register("firstName")}
+            value={volunteer?.firstName}
+            width={isNew ? "160px" : "100%"}
+          />
 
-          <Box w={isNew ? "160px" : "100%"}>
-            {isNew ? (
-              <>
-                <Text
-                  fontSize="xs"
-                  fontWeight="700"
-                  mb={1}
-                >
-                  Last Name
-                </Text>
-                <Input
-                  h="34px"
-                  fontSize="xs"
-                  bg="white"
-                  borderRadius="sm"
-                  borderColor="gray.500"
-                  {...register("lastName")}
-                />
-              </>
-            ) : (
-              <LabeledBox
-                label="Last Name"
-                value={volunteer?.lastName || ""}
-              />
-            )}
-          </Box>
+          <ProfileField
+            label="Last Name"
+            isEditing={isNew || isEditing}
+            registerProps={register("lastName")}
+            value={volunteer?.lastName}
+            width={isNew ? "160px" : "100%"}
+          />
           
           {isNew && (
              <Box w="120px">
@@ -222,53 +240,21 @@ export const VolunteerProfilePanel = ({
              </Box>
           )}
 
-          <Box w={isNew ? "220px" : "100%"}>
-             {isNew ? (
-               <>
-                 <Text fontSize="xs" fontWeight="700" mb={1}>Email Address</Text>
-                 <Input
-                    h="34px"
-                    fontSize="xs"
-                    bg="white"
-                    borderRadius="sm"
-                    borderColor="gray.500"
-                    {...register("email")}
-                 />
-               </>
-             ) : (
-               <LabeledBox
-                 label="Email Address"
-                 value={volunteer?.email || ""}
-               />
-             )}
-          </Box>
+          <ProfileField
+            label="Email Address"
+            isEditing={isNew || isEditing}
+            registerProps={register("email")}
+            value={volunteer?.email}
+            width={isNew ? "220px" : "100%"}
+          />
 
-          <Box w={isNew ? "160px" : "100%"}>
-             {isNew ? (
-               <>
-                 <Text
-                   fontSize="xs"
-                   fontWeight="700"
-                   mb={1}
-                 >
-                   Phone Number
-                 </Text>
-                 <Input
-                    h="34px"
-                    fontSize="xs"
-                    bg="white"
-                    borderRadius="sm"
-                    borderColor="gray.500"
-                    {...register("phoneNumber")}
-                 />
-               </>
-             ) : (
-               <LabeledBox
-                 label="Phone Number"
-                 value={volunteer?.phoneNumber || ""}
-               />
-             )}
-          </Box>
+          <ProfileField
+             label="Phone Number"
+             isEditing={isNew || isEditing}
+             registerProps={register("phoneNumber")}
+             value={volunteer?.phoneNumber || ""}
+             width={isNew ? "160px" : "100%"}
+          />
 
           {!isNew && (
             <>
@@ -279,12 +265,19 @@ export const VolunteerProfilePanel = ({
                   dropdown
                 />
               </Box>
-              <Box w="120px">
-                <LabeledBox
-                  label="Role"
-                  value={volunteer?.role || "Volunteer"}
-                />
-              </Box>
+              <ProfileField
+                label="Role"
+                isEditing={isEditing}
+                registerProps={register("role")}
+                value={volunteer?.role || "Volunteer"}
+                width="120px"
+                type="select"
+                options={[
+                  { value: "volunteer", label: "Volunteer" },
+                  { value: "admin", label: "Admin" },
+                  { value: "staff", label: "Staff" }
+                ]}
+              />
             </>
           )}
         </SimpleGrid>
@@ -372,11 +365,13 @@ export const VolunteerProfilePanel = ({
         )}
 
         {/* Bottom right action */}
-        <Flex mt={10} justify="flex-end">
-          <Button size="sm" variant="outline">
-            {isNew ? "Confirm" : "Save"}
-          </Button>
-        </Flex>
+        {(isNew || isEditing) && (
+          <Flex mt={10} justify="flex-end">
+            <Button size="sm" variant="outline" type="submit">
+              {isNew ? "Confirm" : "Save"}
+            </Button>
+          </Flex>
+        )}
       </Box>
     </Box>
   );

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -11,6 +11,7 @@ import {
 import { useForm } from "react-hook-form";
 import { useEffect } from "react";
 import { Volunteer } from "./VolunteerList";
+import { ChevronLeftIcon } from '@chakra-ui/icons'
 
 interface LabeledBoxProps {
   label: string;
@@ -106,10 +107,13 @@ export const VolunteerProfilePanel = ({
           <Box
             as="button"
             onClick={onBack}
-            style={{ fontSize: 22, marginRight: 12 }}
             aria-label="Back"
+            marginRight={2}
+            _hover={{
+              bg: "gray.200",
+            }}
           >
-            ‹
+            <ChevronLeftIcon />
           </Box>
         )}
 

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -23,7 +23,7 @@ interface LabeledBoxProps {
   dropdown?: boolean;
 }
 
-interface VolunteerProfileFormData {
+export interface VolunteerProfileFormData {
   firstName: string;
   lastName: string;
   role: string;
@@ -167,6 +167,7 @@ export const VolunteerProfilePanel = ({
         email: volunteer.email,
         phoneNumber: volunteer.phoneNumber || "",
         role: volunteer.role || "volunteer",
+        experienceLevel: volunteer.experienceLevel || "beginner",
       });
     }
   }, [volunteer, reset]);
@@ -331,6 +332,20 @@ export const VolunteerProfilePanel = ({
             registerProps={register("phoneNumber")}
             value={volunteer?.phoneNumber || ""}
             width={isNew ? "160px" : "100%"}
+          />
+
+          <ProfileField
+            label="Experience Level"
+            isEditing={isNew || isEditing}
+            registerProps={register("experienceLevel")}
+            value={volunteer?.experienceLevel || "beginner"}
+            width={isNew ? "160px" : "100%"}
+            type="select"
+            options={[
+              { value: "beginner", label: "Beginner" },
+              { value: "intermediate", label: "Intermediate" },
+              { value: "advanced", label: "Advanced" },
+            ]}
           />
 
           {!isNew && (

--- a/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilePanel.tsx
@@ -1,17 +1,20 @@
+import { useEffect, useState } from "react";
+
+import { ChevronLeftIcon } from "@chakra-ui/icons";
 import {
   Box,
+  Button,
   Flex,
   Heading,
-  Text,
-  Button,
-  SimpleGrid,
   Input,
   Select,
+  SimpleGrid,
+  Text,
 } from "@chakra-ui/react";
+
 import { useForm, UseFormRegisterReturn } from "react-hook-form";
-import { useEffect, useState } from "react";
+
 import { Volunteer } from "./VolunteerList";
-import { ChevronLeftIcon } from '@chakra-ui/icons'
 
 interface LabeledBoxProps {
   label: string;
@@ -26,12 +29,22 @@ interface VolunteerProfileFormData {
   role: string;
   email: string;
   phoneNumber: string;
+  experienceLevel: string;
 }
 
-function LabeledBox({ label, width = "100%", value, dropdown = false }: Readonly<LabeledBoxProps>) {
+function LabeledBox({
+  label,
+  width = "100%",
+  value,
+  dropdown = false,
+}: Readonly<LabeledBoxProps>) {
   return (
     <Box>
-      <Text fontSize="xs" fontWeight="700" mb={1}>
+      <Text
+        fontSize="xs"
+        fontWeight="700"
+        mb={1}
+      >
         {label}
       </Text>
       <Flex
@@ -45,7 +58,10 @@ function LabeledBox({ label, width = "100%", value, dropdown = false }: Readonly
         justify="space-between"
         bg="white"
       >
-        <Text fontSize="xs" color="gray.700">
+        <Text
+          fontSize="xs"
+          color="gray.700"
+        >
           {value}
         </Text>
         {dropdown && <Text fontSize="xs">▼</Text>}
@@ -64,26 +80,45 @@ interface ProfileFieldProps {
   options?: { value: string; label: string }[];
 }
 
-const ProfileField = ({ label, isEditing, registerProps, value, width = "100%", type = "text", options }: ProfileFieldProps) => {
+const ProfileField = ({
+  label,
+  isEditing,
+  registerProps,
+  value,
+  width = "100%",
+  type = "text",
+  options,
+}: ProfileFieldProps) => {
   return (
     <Box w={width}>
       {isEditing ? (
         <>
-          <Text fontSize="xs" fontWeight="700" mb={1}>
+          <Text
+            fontSize="xs"
+            fontWeight="700"
+            mb={1}
+          >
             {label}
           </Text>
-          {type === 'select' ? (
-             <Select
-                  h="34px"
-                  fontSize="xs"
-                  bg="white"
-                  borderRadius="sm"
-                  borderColor="gray.500"
-                  iconColor="black"
-                  {...registerProps}
+          {type === "select" ? (
+            <Select
+              h="34px"
+              fontSize="xs"
+              bg="white"
+              borderRadius="sm"
+              borderColor="gray.500"
+              iconColor="black"
+              {...registerProps}
+            >
+              {options?.map((opt) => (
+                <option
+                  key={opt.value}
+                  value={opt.value}
                 >
-                  {options?.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-             </Select>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
           ) : (
             <Input
               h="34px"
@@ -96,7 +131,10 @@ const ProfileField = ({ label, isEditing, registerProps, value, width = "100%", 
           )}
         </>
       ) : (
-        <LabeledBox label={label} value={value || ""} />
+        <LabeledBox
+          label={label}
+          value={value || ""}
+        />
       )}
     </Box>
   );
@@ -106,7 +144,7 @@ interface VolunteerProfilePanelProps {
   variant?: string;
   showBack?: boolean;
   onBack?: () => void;
-  onConfirm?: (data: VolunteerProfileFormData) => void;
+  onConfirm?: (data: VolunteerProfileFormData) => Promise<void> | void;
   volunteer?: Volunteer | null;
 }
 
@@ -133,8 +171,8 @@ export const VolunteerProfilePanel = ({
     }
   }, [volunteer, reset]);
 
-  const onSubmit = (data: VolunteerProfileFormData) => {
-    if (onConfirm) onConfirm(data);
+  const onSubmit = async (data: VolunteerProfileFormData) => {
+    if (onConfirm) await onConfirm(data);
     if (!isNew) setIsEditing(false);
   };
 
@@ -176,7 +214,11 @@ export const VolunteerProfilePanel = ({
         <Box flex="1" />
 
         {!isNew && !isEditing && (
-          <Button size="xs" variant="outline" onClick={() => setIsEditing(true)}>
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => setIsEditing(true)}
+          >
             Edit ↗
           </Button>
         )}
@@ -184,27 +226,56 @@ export const VolunteerProfilePanel = ({
 
       {/* little tags row (lofi) */}
       {!isNew && (
-        <Flex gap={2} align="center" mb={6}>
+        <Flex
+          gap={2}
+          align="center"
+          mb={6}
+        >
           <Text fontSize="sm">Volunteer</Text>
-          <Box px={2} py={1} bg="gray.200" borderRadius="full" fontSize="xs">
+          <Box
+            px={2}
+            py={1}
+            bg="gray.200"
+            borderRadius="full"
+            fontSize="xs"
+          >
             Cases
           </Box>
-          <Box px={2} py={1} bg="gray.200" borderRadius="full" fontSize="xs">
+          <Box
+            px={2}
+            py={1}
+            bg="gray.200"
+            borderRadius="full"
+            fontSize="xs"
+          >
             Workshops
           </Box>
         </Flex>
       )}
 
       {/* Main form container */}
-      <Box bg="gray.50" borderWidth="0px" p={6} as="form" onSubmit={(isNew || isEditing) ? handleSubmit(onSubmit) : undefined}>
+      <Box
+        bg="gray.50"
+        borderWidth="0px"
+        p={6}
+        as="form"
+        onSubmit={isNew || isEditing ? handleSubmit(onSubmit) : undefined}
+      >
         {!isNew && (
-          <Heading size="sm" mb={4}>
+          <Heading
+            size="sm"
+            mb={4}
+          >
             Background Information
           </Heading>
         )}
 
         {/* Profile or New Profile fields */}
-        <SimpleGrid columns={isNew ? 3 : 2} spacing={6} maxW={isNew ? "720px" : "760px"}>
+        <SimpleGrid
+          columns={isNew ? 3 : 2}
+          spacing={6}
+          maxW={isNew ? "720px" : "760px"}
+        >
           <ProfileField
             label="First Name"
             isEditing={isNew || isEditing}
@@ -220,24 +291,30 @@ export const VolunteerProfilePanel = ({
             value={volunteer?.lastName}
             width={isNew ? "160px" : "100%"}
           />
-          
+
           {isNew && (
-             <Box w="120px">
-                <Text fontSize="xs" fontWeight="700" mb={1} >Role</Text>
-                <Select
-                  h="34px"
-                  fontSize="xs"
-                  bg="white"
-                  borderRadius="sm"
-                  borderColor="gray.500"
-                  iconColor="black"
-                  {...register("role")}
-                >
-                  <option value="volunteer">Volunteer</option>
-                  <option value="admin">Admin</option>
-                  <option value="staff">Staff</option>
-                </Select>
-             </Box>
+            <Box w="120px">
+              <Text
+                fontSize="xs"
+                fontWeight="700"
+                mb={1}
+              >
+                Role
+              </Text>
+              <Select
+                h="34px"
+                fontSize="xs"
+                bg="white"
+                borderRadius="sm"
+                borderColor="gray.500"
+                iconColor="black"
+                {...register("role")}
+              >
+                <option value="volunteer">Volunteer</option>
+                {/* <option value="admin">Admin</option>
+                  <option value="staff">Staff</option> */}
+              </Select>
+            </Box>
           )}
 
           <ProfileField
@@ -249,11 +326,11 @@ export const VolunteerProfilePanel = ({
           />
 
           <ProfileField
-             label="Phone Number"
-             isEditing={isNew || isEditing}
-             registerProps={register("phoneNumber")}
-             value={volunteer?.phoneNumber || ""}
-             width={isNew ? "160px" : "100%"}
+            label="Phone Number"
+            isEditing={isNew || isEditing}
+            registerProps={register("phoneNumber")}
+            value={volunteer?.phoneNumber || ""}
+            width={isNew ? "160px" : "100%"}
           />
 
           {!isNew && (
@@ -275,7 +352,7 @@ export const VolunteerProfilePanel = ({
                 options={[
                   { value: "volunteer", label: "Volunteer" },
                   { value: "admin", label: "Admin" },
-                  { value: "staff", label: "Staff" }
+                  { value: "staff", label: "Staff" },
                 ]}
               />
             </>
@@ -285,13 +362,23 @@ export const VolunteerProfilePanel = ({
         {!isNew && (
           <>
             <Box h={8} />
-            <Heading size="sm" mb={4}>
+            <Heading
+              size="sm"
+              mb={4}
+            >
               Volunteer Information
             </Heading>
 
-            <Flex gap={8} wrap="wrap">
+            <Flex
+              gap={8}
+              wrap="wrap"
+            >
               <Box>
-                <Text fontSize="xs" fontWeight="700" mb={1}>
+                <Text
+                  fontSize="xs"
+                  fontWeight="700"
+                  mb={1}
+                >
                   Specialization(s)
                 </Text>
                 <Flex
@@ -303,9 +390,24 @@ export const VolunteerProfilePanel = ({
                   gap={2}
                   align="center"
                 >
-                  <Box w="52px" h="16px" bg="gray.300" borderRadius="full" />
-                  <Box w="56px" h="16px" bg="gray.300" borderRadius="full" />
-                  <Box w="62px" h="16px" bg="gray.300" borderRadius="full" />
+                  <Box
+                    w="52px"
+                    h="16px"
+                    bg="gray.300"
+                    borderRadius="full"
+                  />
+                  <Box
+                    w="56px"
+                    h="16px"
+                    bg="gray.300"
+                    borderRadius="full"
+                  />
+                  <Box
+                    w="62px"
+                    h="16px"
+                    bg="gray.300"
+                    borderRadius="full"
+                  />
                   <Box
                     w="18px"
                     h="18px"
@@ -324,7 +426,11 @@ export const VolunteerProfilePanel = ({
 
                 <Box h={4} />
 
-                <Text fontSize="xs" fontWeight="700" mb={1}>
+                <Text
+                  fontSize="xs"
+                  fontWeight="700"
+                  mb={1}
+                >
                   Languages
                 </Text>
                 <Flex
@@ -335,17 +441,33 @@ export const VolunteerProfilePanel = ({
                   w="fit-content"
                   gap={2}
                 >
-                  <Box px={3} py={1} bg="gray.200" borderRadius="full" fontSize="xs">
+                  <Box
+                    px={3}
+                    py={1}
+                    bg="gray.200"
+                    borderRadius="full"
+                    fontSize="xs"
+                  >
                     English
                   </Box>
-                  <Box px={3} py={1} bg="gray.200" borderRadius="full" fontSize="xs">
+                  <Box
+                    px={3}
+                    py={1}
+                    bg="gray.200"
+                    borderRadius="full"
+                    fontSize="xs"
+                  >
                     Japanese
                   </Box>
                 </Flex>
               </Box>
 
               <Box>
-                <Text fontSize="xs" fontWeight="700" mb={1}>
+                <Text
+                  fontSize="xs"
+                  fontWeight="700"
+                  mb={1}
+                >
                   Law School & Company
                 </Text>
                 <Flex
@@ -357,7 +479,12 @@ export const VolunteerProfilePanel = ({
                   px={3}
                   w="240px"
                 >
-                  <Box w="60px" h="6px" bg="gray.800" borderRadius="sm" />
+                  <Box
+                    w="60px"
+                    h="6px"
+                    bg="gray.800"
+                    borderRadius="sm"
+                  />
                 </Flex>
               </Box>
             </Flex>
@@ -366,8 +493,15 @@ export const VolunteerProfilePanel = ({
 
         {/* Bottom right action */}
         {(isNew || isEditing) && (
-          <Flex mt={10} justify="flex-end">
-            <Button size="sm" variant="outline" type="submit">
+          <Flex
+            mt={10}
+            justify="flex-end"
+          >
+            <Button
+              size="sm"
+              variant="outline"
+              type="submit"
+            >
               {isNew ? "Confirm" : "Save"}
             </Button>
           </Flex>
@@ -375,4 +509,4 @@ export const VolunteerProfilePanel = ({
       </Box>
     </Box>
   );
-}
+};

--- a/client/src/components/volunteerManagement/VolunteerProfilesPanel.tsx
+++ b/client/src/components/volunteerManagement/VolunteerProfilesPanel.tsx
@@ -1,24 +1,51 @@
+import { useEffect, useState } from "react";
+
 import {
   Box,
   Flex,
-  Text,
   Table,
-  Thead,
   Tbody,
-  Tr,
-  Th,
   Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
 } from "@chakra-ui/react";
 
+import { useBackendContext } from "@/contexts/hooks/useBackendContext";
+
 interface VolunteerProfilesPanelProps {
-  variant?: string;
+  variant?: "list" | "table";
 }
 
-export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPanelProps) => {
+export const VolunteerProfilesPanel = ({
+  variant = "list",
+}: VolunteerProfilesPanelProps) => {
+  type Volunteer = {
+    id: number;
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+
+  const [volunteers, setVolunteers] = useState<Volunteer[]>([]);
+  const { backend } = useBackendContext();
+
+  useEffect(() => {
+    (async () => {
+      const res = await backend.get<Volunteer[]>("/volunteers");
+      setVolunteers(res.data);
+    })();
+  }, [backend]);
+
   return (
     <Box>
       {variant === "list" && (
-        <Box mt={4} borderWidth="1px" borderColor="gray.200">
+        <Box
+          mt={4}
+          borderWidth="1px"
+          borderColor="gray.200"
+        >
           <Table size="md">
             <Thead>
               <Tr>
@@ -26,8 +53,8 @@ export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPa
               </Tr>
             </Thead>
             <Tbody>
-              {Array.from({ length: 12 }).map((_, i) => (
-                <Tr key={i}>
+              {volunteers.map((volunteer) => (
+                <Tr key={volunteer.id}>
                   <Td>
                     <Flex align="center">
                       <Box
@@ -38,11 +65,17 @@ export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPa
                         borderRadius="full"
                         mr={3}
                       />
-                      <Text fontSize="sm" flex="1">
-                        [Username]
+                      <Text
+                        fontSize="sm"
+                        flex="1"
+                      >
+                        {volunteer.firstName} {volunteer.lastName}
                       </Text>
-                      <Text fontSize="sm" color="gray.700">
-                        {i % 3 === 0 ? "Staff" : "Volunteer"}
+                      <Text
+                        fontSize="sm"
+                        color="gray.700"
+                      >
+                        Volunteer
                       </Text>
                     </Flex>
                   </Td>
@@ -54,22 +87,29 @@ export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPa
       )}
 
       {variant === "table" && (
-        <Box mt={4} borderWidth="1px" borderColor="gray.200">
+        <Box
+          mt={4}
+          borderWidth="1px"
+          borderColor="gray.200"
+        >
           <Table size="md">
             <Thead>
               <Tr>
                 <Th fontSize="xs">Name</Th>
                 <Th fontSize="xs">Role</Th>
-                <Th fontSize="xs">Join Date</Th>
+                <Th fontSize="xs">Email</Th>
                 <Th fontSize="xs">Active Date</Th>
                 <Th />
               </Tr>
             </Thead>
             <Tbody>
-              {Array.from({ length: 11 }).map((_, i) => (
-                <Tr key={i}>
+              {volunteers.map((volunteer) => (
+                <Tr key={volunteer.id}>
                   <Td>
-                    <Flex align="center" gap={3}>
+                    <Flex
+                      align="center"
+                      gap={3}
+                    >
                       <Box
                         w="24px"
                         h="24px"
@@ -77,13 +117,18 @@ export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPa
                         borderColor="gray.400"
                         borderRadius="full"
                       />
-                      <Text fontSize="sm">[Username]</Text>
+                      <Text fontSize="sm">
+                        {volunteer.firstName} {volunteer.lastName}
+                      </Text>
                     </Flex>
                   </Td>
-                  <Td fontSize="sm">{i % 4 === 0 ? "Staff" : "Volunteer"}</Td>
-                  <Td fontSize="sm">February 10, 2025</Td>
+                  <Td fontSize="sm">Volunteer</Td>
+                  <Td fontSize="sm">{volunteer.email}</Td>
                   <Td fontSize="sm">-------------</Td>
-                  <Td textAlign="right" fontSize="18px">
+                  <Td
+                    textAlign="right"
+                    fontSize="18px"
+                  >
                     🗑️
                   </Td>
                 </Tr>
@@ -94,4 +139,4 @@ export const VolunteerProfilesPanel = ({ variant = "list" }: VolunteerProfilesPa
       )}
     </Box>
   );
-}
+};

--- a/client/src/types/volunteer.ts
+++ b/client/src/types/volunteer.ts
@@ -1,0 +1,11 @@
+export interface Volunteer {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber?: string;
+  role?: string;
+  specializations?: string[];
+  languages?: string[];
+  experienceLevel?: string;
+}


### PR DESCRIPTION
## Description
Connected backend to volunteer management frontend.
- All views populate with volunteer data
- Volunteers can be deleted via the trash emoji
- Volunteers can be edited using the edit -> save flow
- Volunteers can be created with the add profile -> confirm flow
- Making a POST/PUT/DELETE updates the frontend accordingly

Made minor UI changes to better align with the Lo-Fi V2
- Removed the Profile-Only view
- Added distinctive highlighting for the selected user
- Removed View Switcher, navigation is now done via:
  - Selecting a user (clicking will switch to the split view)
  - Clicking the back button on a user (will return to table view)
- Added an experience level field since that is non-nullable

## Screenshots/Media
> [!NOTE]
> Code Section 
<img width="1228" height="868" alt="64902" src="https://github.com/user-attachments/assets/a558dff4-2c25-4e58-9871-db5b204c973a" />
<img width="1008" height="1264" alt="15126" src="https://github.com/user-attachments/assets/bdc2c7ad-b9d8-48de-b044-51de34218734" />


> [!NOTE]
> Image Section
<img width="3956" height="2512" alt="CleanShot 2026-01-28 at 15 26 55@2x" src="https://github.com/user-attachments/assets/0aa9f252-5ad3-4770-a204-c680fe38e9c8" />

## Issues
Closes #54 

<!-- [Optional]
## Additional Notes
-->
