### PR TITLE
changed clinic schema

### DIFF
--- a/server/db/schema/clinics.sql
+++ b/server/db/schema/clinics.sql
@@ -1,5 +1,3 @@
-CREATE TYPE experience_level AS ENUM ('beginner', 'intermediate', 'advanced');
-
 CREATE TABLE clinics (
     id serial PRIMARY KEY,
     name TEXT NOT NULL,
@@ -9,10 +7,9 @@ CREATE TABLE clinics (
     end_time TIMESTAMPTZ NOT NULL,
     date DATE NOT NULL,
     attendees INT NOT NULL DEFAULT 0 CHECK (attendees >= 0),
+    min_attendees INT NOT NULL CHECK (min_attendees > 0),
     capacity INT NOT NULL CHECK (capacity > 0),
     max_target_roles INT NOT NULL,
-    language TEXT,
-    experience_level experience_level NOT NULL,
     parking TEXT
 );
 

--- a/server/routes/clinics.js
+++ b/server/routes/clinics.js
@@ -15,13 +15,13 @@ clinicsRouter.post("/", async (req, res) => {
       end_time,
       date,
       attendees,
+      min_attendees,
       capacity,
       max_target_roles,
-      experience_level,
       parking,
     } = req.body;
     const clinic = await db.query(
-      `INSERT INTO clinics (name, description, location, start_time, end_time, date, attendees, capacity, max_target_roles, experience_level, parking)
+      `INSERT INTO clinics (name, description, location, start_time, end_time, date, attendees, min_attendees, capacity, max_target_roles, parking)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING *`,
       [
         name,
@@ -31,9 +31,9 @@ clinicsRouter.post("/", async (req, res) => {
         end_time,
         date,
         attendees,
+        min_attendees,
         capacity,
         max_target_roles,
-        experience_level,
         parking,
       ]
     );
@@ -79,13 +79,13 @@ clinicsRouter.put("/:id", async (req, res) => {
       end_time,
       date,
       attendees,
+      min_attendees,
       capacity,
       max_target_roles,
-      experience_level,
       parking,
     } = req.body;
     const clinic = await db.query(
-      `UPDATE clinics SET name = $1, description = $2, location = $3, start_time = $4, end_time = $5, date = $6, attendees = $7, capacity = $8, max_target_roles = $9, experience_level = $10, parking = $11
+      `UPDATE clinics SET name = $1, description = $2, location = $3, start_time = $4, end_time = $5, date = $6, attendees = $7, min_attendees = $8, capacity = $9, max_target_roles = $10, parking = $11
        WHERE id = $12 RETURNING *`,
       [
         name,
@@ -95,9 +95,9 @@ clinicsRouter.put("/:id", async (req, res) => {
         end_time,
         date,
         attendees,
+        min_attendees,
         capacity,
         max_target_roles,
-        experience_level,
         parking,
         id,
       ]


### PR DESCRIPTION
## Description
Updated Clinic to satisfy new NPO requirements:
- Modified Clinic db schema
  - Updated `time` to `start_time` and added `end_time` (both type `TIMESTAMPTZ NOT NULL`
  - Added `capacity INT NOT NULL CHECK (capacity > 0)`
  - Added `max_target_roles INT NOT NULL` (wasn't sure if this should have a check)
- Updated Clinic endpoints (POST and PUT)
  - Added/updated above fields
> [!WARNING]
> We have `language` as a `TEXT` field in our schema for `clinic` but that doesn't make sense since it should probably be a foreign key language id—language isn't currently in the endpoint so I didn't add it, but it's in the schema... 

> [!CAUTION]
> I noticed half of the schemas use `CREATE TABLE` and not `CREATE TABLE IF NOT EXISTS`, not sure if that matters.

> [!IMPORTANT]
>  I do not know how to update the NeonDB and as a result I cannot test the endpoints, but they should at least be *ready* to test.

## Screenshots/Media
<img width="1200" height="832" alt="66327" src="https://github.com/user-attachments/assets/66fcc8cd-7927-4e78-8386-5fc20dd0b91a" />
<img width="2528" height="1624" alt="41994" src="https://github.com/user-attachments/assets/0e911d01-5fa8-4c17-ad54-e2d87166ca0f" />
<img width="3326" height="1804" alt="65320" src="https://github.com/user-attachments/assets/0bbf949c-758f-4499-8819-1aaa87c573d3" />

## Issues
Closes #58 #63 

<!-- [Optional]
## Additional Notes
-->
