### PR TITLE
app.tsx revert i am chuzz

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,18 +10,15 @@ import { Signup } from "@/components/signup/Signup";
 import { Playground } from "@/components/playground/Playground";
 
 // Dev-made Components!
-// import { AdminProfile } from "@/components/adminProfile/adminProfile";
 import { EventCatalog } from "@/components/eventCatalog/eventCatalog";
-// import { AdminLogin } from "@/components/adminProfile/adminLogin";
-// import { EventCatalog } from "@/components/eventCatalog/eventCatalog";
+import { AdminProfile } from "@/components/adminProfile/adminProfile";
 import { AdminLogin } from "@/components/adminProfile/adminLogin";
 import { AdminForgotPass } from "./components/adminProfile/adminForgotPass";
-import { AdminPassReset} from "./components/adminProfile/adminPassReset";
+import { AdminPassReset } from "./components/adminProfile/adminPassReset";
 import { VolunteerManagement } from "./components/volunteerManagement/VolunteerManagement";
-import { AddProfileView } from "./components/volunteerManagement/AddProfileView";
-import { StaffLayout } from "./components/staff/StaffLayout";
-// import { VolunteerProfile } from "@/components/volunteerProfile/volunteerProfile";
+import { StaffLayout } from "./components/navbar/StaffLayout";
 import { VolunteerLayout } from "./components/navbar/VolunteerLayout";
+import { VolunteerProfile } from "@/components/volunteerProfile/volunteerProfile";
 import { EmailTemplateManagement } from "@/components/emailTemplateManagement/emailTemplateManagement";
 import { VolunteerLogin } from "./components/volunteerLogin/volunteerLogin";
 import { TagManagement } from "@/components/tagManagement/tagManagement";
@@ -67,53 +64,54 @@ const App = () => {
           <RoleProvider>
             <Router>
               <Routes>
-                {/* Dev-made Routes! */}
-                <Route
-                  path="/adminLogin"
-                  element={<AdminLogin/>}
-                />
-                <Route
-                  path = "/adminForgotPass"
-                  element = {<AdminForgotPass/>}
-                >
-                </Route>
-
-                <Route
-                  path = "/adminPassReset"
-                  element = {<AdminPassReset/>}
-                >
-                </Route>
-                
-                {/* <Route
-                  path="/volunteerProfile"
-                  element={<VolunteerProfile />}
-                /> */}
-                
-                <Route
-                  path="/email"
-                  element={<EmailTemplateManagement />}
-                />
-                <Route
-                  path="/email/folder/:folderId"
-                  element={<EmailTemplateManagement />}
-                />
-                <Route
-                  path="/email/template/:templateId"
-                  element={<EmailTemplateManagement />}
-                />
-                {/* <Route
-                  path="/catalog"
-                  element={<CaseCatalog />}
-                /> */}
-                
+                {/* DEV-MADE ROUTES! */}
+                {/* Staff: full AdminNavbar (email, events landing, tags, admin) */}
                 <Route
                   element={
                     <ProtectedRoute
-                      element={<StaffLayout />}
+                      element={<StaffLayout navbar="expanded" />}
                       allowedRoles={["staff", "supervisor"]}
                     />
                   }
                 >
+                  <Route
+                    path="/email"
+                    element={<EmailTemplateManagement />}
+                  />
+                  <Route
+                    path="/email/folder/:folderId"
+                    element={<EmailTemplateManagement />}
+                  />
+                  <Route
+                    path="/email/template/:templateId"
+                    element={<EmailTemplateManagement />}
+                  />
+                  <Route path="/events" element={<EventManagement />} />
+                  <Route path="/manage-tags/*" element={<TagManagement />} />
+                  <Route
+                    path="/admin"
+                    element={
+                      <ProtectedRoute
+                        element={<Admin />}
+                        allowedRoles={["staff", "supervisor"]}
+                      />
+                    }
+                  />
+                </Route>
+
+                {/* Staff: collapsed sidebar (volunteer management, events sub-pages) */}
+                <Route
+                  element={
+                    <ProtectedRoute
+                      element={<StaffLayout navbar="collapsed" />}
+                      allowedRoles={["staff", "supervisor"]}
+                    />
+                  }
+                >
+                  <Route
+                    path="/admin-profile"
+                    element={<AdminProfile />}
+                  />
                   <Route
                     path="/volunteer-management"
                     element={<VolunteerManagement />}
@@ -141,62 +139,25 @@ const App = () => {
                   <Route
                     path="/volunteer-profile"
                     element={
-                      <ProtectedRoute
-                        element={<AddProfileView />}
-                        allowedRoles={["supervisor", "staff"]}
+                      <Navigate
+                        to="/volunteer-profile/information"
+                        replace
                       />
                     }
                   />
                   <Route
-                    path="/admin"
+                    path="/volunteer-profile/:tab"
                     element={
                       <ProtectedRoute
-                        element={<Admin />}
-                        allowedRoles={["staff", "supervisor"]}
+                        element={<VolunteerProfile />}
+                        allowedRoles={["volunteer"]}
                       />
                     }
                   />
                 </Route>
-                {/* <Route
-                  path = "/events"
-                  element={
-                    <ProtectedRoute
-                      element={<EventManagement />}
-                      allowedRoles={["admin"]}
-                    />
-                  }
-                /> */}
-                {/* <Route
-                  path = "/events/:id"
-                  element={
-                    <ProtectedRoute
-                      element={<EventDetail />}
-                      allowedRoles={["admin"]}
-                    />
-                  }
-                /> */}
-                <Route
-                  path="/volunteerLogin"
-                  element={<VolunteerLogin />}
-                />
-                <Route 
-                  path="/event-catalog"
-                  element={<EventCatalog />}
-                />
-                {/* <Route
-                  path="/admin-profile"
-                  element={<AdminProfile />}
-                /> */}
-                {/* <Route
-                  path="/caseManagement"
-                  element={<CaseManagement />}
-                /> */}
-                
+
                 {/* Playground Routes (Don't Touch!) */}
-                <Route
-                  path="/playground"
-                  element={<Playground />}
-                />
+                <Route path="/playground" element={<Playground />} />
 
                 {/* Core Routes (Don't Touch!) */}
                 <Route
@@ -215,6 +176,10 @@ const App = () => {
                   path="/login/staff"
                   element={<AdminLogin />}
                 />
+                <Route path="/adminLogin" element={<AdminLogin />} />
+                <Route path="/adminForgotPass" element={<AdminForgotPass />} />
+                <Route path="/adminPassReset" element={<AdminPassReset />} />
+
                 <Route
                   path="/signup"
                   element={<Signup />}
@@ -225,19 +190,13 @@ const App = () => {
                 />
                 <Route
                   path="/"
-                  element={
-                    <Navigate
-                      to="/login"
-                      replace
-                    />
-                  }
+                  element={<Navigate to="/login" replace />}
                 />
 
                 <Route
                   path="*"
                   element={<ProtectedRoute element={<CatchAll />} />}
                 />
-
               </Routes>
             </Router>
           </RoleProvider>

--- a/client/src/components/ui/provider.tsx
+++ b/client/src/components/ui/provider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { ChakraProvider } from "@chakra-ui/react"
-import { eldr } from "./theme"
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react"
+//import { eldr } from "./theme"
 import {
   ColorModeProvider,
   type ColorModeProviderProps,
@@ -9,7 +9,7 @@ import {
 
 export function Provider(props: ColorModeProviderProps) {
   return (
-    <ChakraProvider value={eldr}>
+    <ChakraProvider value={defaultSystem}>
       <ColorModeProvider
         // Match Chakra v2 default behavior: start in light mode
         defaultTheme="light"


### PR DESCRIPTION
## Description
big chuzz
## Screenshots/Media

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the staff navbar state by splitting routes into expanded vs. collapsed `StaffLayout` variants and tightening role guards. Also switches the Chakra provider to `defaultSystem` to resolve text input styling issues.

- Bug Fixes
  - Stable navbar: expanded for admin/email/events; collapsed for volunteer management and event sub-pages.
  - Correct volunteer profile routing: redirect to default tab, use `:tab` param, and guard with the `volunteer` role.
  - Inputs render correctly by using `@chakra-ui/react` `defaultSystem` in the provider.

- Refactors
  - Grouped admin/email/tag/event routes under a protected staff layout; added `/admin-profile`.
  - Moved `StaffLayout` to `components/navbar/StaffLayout` and added `navbar="expanded" | "collapsed"`.
  - Added explicit admin auth routes (`/adminLogin`, `/adminForgotPass`, `/adminPassReset`) and simplified redirects; removed dead/commented routes.

<sup>Written for commit d54b2d9d2c256f65e8c8ac5dd38bcd5c2352a466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

