### PR TITLE
fix: fixed bug for add profile button not working

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import { AdminLogin } from "@/components/adminProfile/adminLogin";
 import { AdminForgotPass } from "./components/adminProfile/adminForgotPass";
 import { AdminPassReset } from "./components/adminProfile/adminPassReset";
 import { VolunteerManagement } from "./components/volunteerManagement/VolunteerManagement";
+import { AddProfileView } from "./components/volunteerManagement/AddProfileView";
 import { StaffLayout } from "./components/navbar/StaffLayout";
 import { VolunteerLayout } from "./components/navbar/VolunteerLayout";
 import { VolunteerProfile } from "@/components/volunteerProfile/volunteerProfile";
@@ -115,6 +116,10 @@ const App = () => {
                   <Route
                     path="/volunteer-management"
                     element={<VolunteerManagement />}
+                  />
+                  <Route 
+                    path="/volunteer-management/new" 
+                    element={<AddProfileView />} 
                   />
                   <Route
                     path="/events/:eventId/email-notification/new"


### PR DESCRIPTION
## Description
what the top says
## Screenshots/Media
it works trust me
## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Add Profile” button in Volunteer Management by adding the missing route to the new profile form. Users can now navigate to create a new volunteer profile.

- **Bug Fixes**
  - Added Route for "/volunteer-management/new" to render `AddProfileView` (in App.tsx).

<sup>Written for commit 5a2285e1822a3654623f952197fd20a288898f71. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/eldr/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

