### PR TITLE
Clinic Catalog Changes

### DIFF
--- a/client/src/components/eventCatalog/eventCatalog.jsx
+++ b/client/src/components/eventCatalog/eventCatalog.jsx
@@ -31,7 +31,7 @@ export const EventCatalog = () => {
   const { backend } = useBackendContext();
   const { currentUser } = useAuthContext();
 
-  const [filtersApplied, setFiltersApplied] = useState(false);
+  const [applyToken, setApplyToken] = useState(0);
   const [filteredCount, setFilteredCount] = useState(0);
 
   const { view: catalogView, eventId: parsedEventId } = parseEventCatalogPath(
@@ -166,15 +166,30 @@ export const EventCatalog = () => {
           data = res.data;
         }
 
-        const count = data.filter((e) => {
+        let candidates = data.filter((e) => {
           if (catalogView === "catalog") {
             if (!e.endTime) return true;
             return new Date(e.endTime) > now;
           }
           return true;
-        }).length;
+        });
 
-        setFilteredCount(count);
+        // "My Events" only shows events the volunteer is registered for —
+        // mirror that here so the preview count matches what Apply will show.
+        if (catalogView === "my") {
+          const registered = await Promise.all(
+            candidates.map((e) =>
+              backend
+                .get(`/clinics/${e.id}/registrations`)
+                .then((regRes) =>
+                  regRes.data.some((reg) => reg.id === volunteerId)
+                )
+            )
+          );
+          candidates = candidates.filter((_, i) => registered[i]);
+        }
+
+        setFilteredCount(candidates.length);
       } catch (error) {
         console.error("Failed to fetch filtered event count:", error);
         setFilteredCount(0);
@@ -184,33 +199,39 @@ export const EventCatalog = () => {
     fetchFilteredCount();
   }, [selectedFilters, volunteerId, catalogView]);
 
-  // Fetch and apply filtered events only when the apply button is pressed
+  // Fetch and apply filtered events only when the apply button is pressed.
+  // `applyToken` is a counter rather than a boolean so that two applies
+  // requested back-to-back (before the first fetch resolves) each still
+  // produce a distinct value and reliably re-trigger this effect.
   useEffect(() => {
-    if (!filtersApplied || !volunteerId) return;
+    if (applyToken === 0 || !volunteerId) return;
+
+    let cancelled = false;
 
     const fetchFilteredEvents = async () => {
       try {
+        let enrichedEvents;
         if (selectedFilters.length > 0) {
           const params = buildFilterParams(selectedFilters);
-          console.log("EVENTS", params.toString());
           const res = await backend.get(`/clinics/search?${params.toString()}`);
-          const enrichedEvents = await enrichEvents(res.data, volunteerId);
-          setEvents(enrichedEvents);
+          enrichedEvents = await enrichEvents(res.data, volunteerId);
         } else {
           const res = await backend.get("/clinics");
-          console.log("EVENTS RESPONSE", res.data.length);
-          const enrichedEvents = await enrichEvents(res.data, volunteerId);
-          setEvents(enrichedEvents);
+          enrichedEvents = await enrichEvents(res.data, volunteerId);
         }
+        // Ignore results from a stale apply that resolved after a newer one.
+        if (!cancelled) setEvents(enrichedEvents);
       } catch (error) {
         console.error("Failed to fetch filtered events:", error);
-      } finally {
-        setFiltersApplied(false);
       }
     };
 
     fetchFilteredEvents();
-  }, [filtersApplied, volunteerId]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applyToken, volunteerId]);
 
   // Events filtered by tab/time but NOT search, used for suggestions
   const tabEvents = useMemo(() => {
@@ -375,7 +396,7 @@ export const EventCatalog = () => {
             selectedFilters={selectedFilters}
             setSelectedFilters={setSelectedFilters}
             filteredCount={filteredCount}
-            onApplyFilters={() => setFiltersApplied(true)}
+            onApplyFilters={() => setApplyToken((t) => t + 1)}
             events={tabEvents}
           />
 

--- a/client/src/components/eventCatalog/eventCatalog.jsx
+++ b/client/src/components/eventCatalog/eventCatalog.jsx
@@ -154,23 +154,35 @@ export const EventCatalog = () => {
       }
 
       try {
-        const params = buildFilterParams(selectedFilters);
-        console.log("COUNT", params.toString());
-        const res = await backend.get(`/clinics/search?${params.toString()}`);
-        console.log("COUNT RESPONSE", res.data.length);
-        setFilteredCount(res.data?.length ?? 0);
+        const now = new Date();
+        let data;
+
+        if (selectedFilters.length > 0) {
+          const params = buildFilterParams(selectedFilters);
+          const res = await backend.get(`/clinics/search?${params.toString()}`);
+          data = res.data;
+        } else {
+          const res = await backend.get("/clinics");
+          data = res.data;
+        }
+
+        const count = data.filter((e) => {
+          if (catalogView === "catalog") {
+            if (!e.endTime) return true;
+            return new Date(e.endTime) > now;
+          }
+          return true;
+        }).length;
+
+        setFilteredCount(count);
       } catch (error) {
         console.error("Failed to fetch filtered event count:", error);
-        setFilteredCount(res.data?.length ?? 0);
+        setFilteredCount(0);
       }
     };
 
-    if (selectedFilters.length > 0) {
-      fetchFilteredCount();
-    } else {
-      fetchFilteredCount();
-    }
-  }, [selectedFilters, volunteerId]);
+    fetchFilteredCount();
+  }, [selectedFilters, volunteerId, catalogView]);
 
   // Fetch and apply filtered events only when the apply button is pressed
   useEffect(() => {

--- a/client/src/components/eventCatalog/eventCatalog.jsx
+++ b/client/src/components/eventCatalog/eventCatalog.jsx
@@ -31,6 +31,9 @@ export const EventCatalog = () => {
   const { backend } = useBackendContext();
   const { currentUser } = useAuthContext();
 
+  const [filtersApplied, setFiltersApplied] = useState(false);
+  const [filteredCount, setFilteredCount] = useState(0);
+
   const { view: catalogView, eventId: parsedEventId } = parseEventCatalogPath(
     location.pathname
   );
@@ -95,6 +98,34 @@ export const EventCatalog = () => {
     );
   };
 
+  // Helper: build filter query params from selectedFilters
+  const buildFilterParams = (filters) => {
+    const areaIds = [];
+    const langIds = [];
+    const roleIds = [];
+    const locs = [];
+
+    filters.forEach((filter) => {
+      if (filter.id.startsWith("areasOfPracticeId")) {
+        areaIds.push(filter.id.replace("areasOfPracticeId", ""));
+      } else if (filter.id.startsWith("languageId")) {
+        langIds.push(filter.id.replace("languageId", ""));
+      } else if (filter.id.startsWith("roleId")) {
+        roleIds.push(filter.id.replace("roleId", ""));
+      } else {
+        locs.push(filter.id);
+      }
+    });
+
+    const params = new URLSearchParams();
+    if (areaIds.length > 0) params.set("areaOfPracticeIds", areaIds.join(","));
+    if (langIds.length > 0) params.set("languageIds", langIds.join(","));
+    if (roleIds.length > 0) params.set("roleIds", roleIds.join(","));
+    if (locs.length > 0) params.set("locations", locs.join(","));
+
+    return params;
+  };
+
   // Initial fetch - get volunteer ID and all events
   useEffect(() => {
     const fetchFullEventData = async () => {
@@ -113,6 +144,61 @@ export const EventCatalog = () => {
 
     fetchFullEventData();
   }, [backend, currentUser?.uid]);
+
+  // Update the count preview whenever filters change (no button press needed)
+  useEffect(() => {
+    const fetchFilteredCount = async () => {
+      if (!volunteerId) {
+        setFilteredCount(0);
+        return;
+      }
+
+      try {
+        const params = buildFilterParams(selectedFilters);
+        console.log("COUNT", params.toString());
+        const res = await backend.get(`/clinics/search?${params.toString()}`);
+        console.log("COUNT RESPONSE", res.data.length);
+        setFilteredCount(res.data?.length ?? 0);
+      } catch (error) {
+        console.error("Failed to fetch filtered event count:", error);
+        setFilteredCount(res.data?.length ?? 0);
+      }
+    };
+
+    if (selectedFilters.length > 0) {
+      fetchFilteredCount();
+    } else {
+      fetchFilteredCount();
+    }
+  }, [selectedFilters, volunteerId]);
+
+  // Fetch and apply filtered events only when the apply button is pressed
+  useEffect(() => {
+    if (!filtersApplied || !volunteerId) return;
+
+    const fetchFilteredEvents = async () => {
+      try {
+        if (selectedFilters.length > 0) {
+          const params = buildFilterParams(selectedFilters);
+          console.log("EVENTS", params.toString());
+          const res = await backend.get(`/clinics/search?${params.toString()}`);
+          const enrichedEvents = await enrichEvents(res.data, volunteerId);
+          setEvents(enrichedEvents);
+        } else {
+          const res = await backend.get("/clinics");
+          console.log("EVENTS RESPONSE", res.data.length);
+          const enrichedEvents = await enrichEvents(res.data, volunteerId);
+          setEvents(enrichedEvents);
+        }
+      } catch (error) {
+        console.error("Failed to fetch filtered events:", error);
+      } finally {
+        setFiltersApplied(false);
+      }
+    };
+
+    fetchFilteredEvents();
+  }, [filtersApplied, volunteerId]);
 
   // Events filtered by tab/time but NOT search, used for suggestions
   const tabEvents = useMemo(() => {
@@ -208,65 +294,6 @@ export const EventCatalog = () => {
     }
   };
 
-  // fetch filtered events when filters change
-  useEffect(() => {
-    const fetchFilteredEvents = async () => {
-      if (!volunteerId) return;
-
-      try {
-        // group filter IDs by category for making API query params
-        const areaIds = [];
-        const langIds = [];
-        const roleIds = [];
-        const locs = [];
-
-        selectedFilters.forEach((filter) => {
-          if (filter.id.startsWith("areasOfPracticeId")) {
-            areaIds.push(filter.id.replace("areasOfPracticeId", ""));
-          } else if (filter.id.startsWith("languageId")) {
-            langIds.push(filter.id.replace("languageId", ""));
-          } else if (filter.id.startsWith("roleId")) {
-            roleIds.push(filter.id.replace("roleId", ""));
-          } else {
-            locs.push(filter.id);
-          }
-        });
-
-        // build query params with comma-separated values
-        const params = new URLSearchParams();
-        if (areaIds.length > 0)
-          params.set("areaOfPracticeIds", areaIds.join(","));
-        if (langIds.length > 0) params.set("languageIds", langIds.join(","));
-        if (roleIds.length > 0) params.set("roleIds", roleIds.join(","));
-        if (locs.length > 0) params.set("locations", locs.join(","));
-
-        const res = await backend.get(`/clinics/search?${params.toString()}`);
-        const enrichedEvents = await enrichEvents(res.data, volunteerId);
-        setEvents(enrichedEvents);
-      } catch (error) {
-        console.error("Failed to fetch filtered events:", error);
-      }
-    };
-
-    const fetchAllEvents = async () => {
-      if (!volunteerId) return;
-
-      try {
-        const res = await backend.get("/clinics");
-        const enrichedEvents = await enrichEvents(res.data, volunteerId);
-        setEvents(enrichedEvents);
-      } catch (error) {
-        console.error("Failed to fetch all events:", error);
-      }
-    };
-
-    if (selectedFilters.length > 0) {
-      fetchFilteredEvents();
-    } else if (volunteerId) {
-      fetchAllEvents();
-    }
-  }, [selectedFilters, volunteerId, backend]);
-
   const [registrationPending, setRegistrationPending] = useState(null);
 
   const handleRegister = async (clinicId) => {
@@ -335,7 +362,8 @@ export const EventCatalog = () => {
             setSearchQuery={setSearchQuery}
             selectedFilters={selectedFilters}
             setSelectedFilters={setSelectedFilters}
-            filteredCount={filteredEvents.length}
+            filteredCount={filteredCount}
+            onApplyFilters={() => setFiltersApplied(true)}
             events={tabEvents}
           />
 

--- a/client/src/components/eventCatalog/eventCatalog.jsx
+++ b/client/src/components/eventCatalog/eventCatalog.jsx
@@ -408,6 +408,7 @@ export const EventCatalog = () => {
           direction="column"
           overflow="hidden"
           align="start"
+          bg="white"
           px={{ base: "12px", md: "none" }}
         >
           {/* Back Button */}

--- a/client/src/components/eventCatalog/eventInfo.jsx
+++ b/client/src/components/eventCatalog/eventInfo.jsx
@@ -30,6 +30,8 @@ import { LuCalendarDays } from "react-icons/lu";
 import { formatLocationTypeTag, getClinicLocationDisplay } from "./clinicLocationFormat";
 import RegStatus from "./regStatus";
 
+import { useNavigate } from "react-router-dom";
+
 export const EventInfo = ({
   event,
   activeTab,
@@ -49,6 +51,8 @@ export const EventInfo = ({
       return () => clearTimeout(timer);
     }
   }, [showCopyMessage]);
+
+  const navigate = useNavigate();
 
   const handleRegistration = () => {
     if (event.isRegistered) {
@@ -110,6 +114,7 @@ export const EventInfo = ({
             <Button
               bg="#487C9E"
               p={6}
+              onClick={() => navigate("/all-events")}
             >
               <LuCalendarDays />
               View All Events
@@ -120,7 +125,6 @@ export const EventInfo = ({
     );
   }
 
-  // Determine if this is a past event using the same logic as MyEventsList
   const getEventEndDateTime = () => {
     const dateObj = event.date ? new Date(event.date) : null;
     if (dateObj && event.endTime) {
@@ -188,28 +192,33 @@ export const EventInfo = ({
     >
       <HStack
         justify="space-between"
+        align="flex-start"
         mb="20px"
+        gap={3}
+        minW={0}
       >
         <Text
-          flexShrink={0}
-          fontSize="26px"
+          fontSize={{ base: "20px", md: "26px" }}
           fontWeight="bold"
-          lineHeight="44px"
+          lineHeight={{ base: "28px", md: "44px" }}
           letterSpacing="-2.5%"
           color="#000000"
+          wordBreak="break-word"
+          minW={0}
+          flex="1"
         >
           {event.name}
         </Text>
 
         {activeTab === "catalog" && (
-          <Box position="relative">
+          <Box position="relative" flexShrink={0}>
             <Box
               position="absolute"
               bottom="100%"
               right={0}
               mb={2}
               bg="#487C9E"
-              color="white"
+              color="whiteAlpha/0"
               rounded="md"
               fontWeight={500}
               fontSize="xs"
@@ -249,8 +258,11 @@ export const EventInfo = ({
           display="flex"
           alignItems="center"
           gap="18px"
+          wordBreak="break-word"
+          minW={0}
+          w="full"
         >
-          <CalendarDays />
+          <Box flexShrink={0}><CalendarDays /></Box>
           {event.displayDate}
         </Text>
         <Separator
@@ -261,8 +273,12 @@ export const EventInfo = ({
           display="flex"
           alignItems="center"
           gap="18px"
+          wordBreak="break-word"
+          minW={0}
+          w="full"
         >
-          <CalendarClock /> {event.displayTime}
+          <Box flexShrink={0}><CalendarClock /></Box>
+          {event.displayTime}
         </Text>
         <Separator
           w="full"
@@ -271,6 +287,8 @@ export const EventInfo = ({
         <Flex
           alignItems="flex-start"
           gap="18px"
+          w="full"
+          minW={0}
         >
           <Box
             flexShrink={0}
@@ -282,8 +300,9 @@ export const EventInfo = ({
             align="flex-start"
             gap="4px"
             flex="1"
+            minW={0}
           >
-            <Text lineHeight="1.4">{localityLine}</Text>
+            <Text lineHeight="1.4" wordBreak="break-word">{localityLine}</Text>
             {showMeetingLink ? (
               <Text
                 as="a"
@@ -294,6 +313,7 @@ export const EventInfo = ({
                 fontSize="13px"
                 fontWeight={500}
                 textDecoration="underline"
+                wordBreak="break-all"
               >
                 Meeting link
               </Text>
@@ -308,8 +328,12 @@ export const EventInfo = ({
           display="flex"
           alignItems="center"
           gap="18px"
+          wordBreak="break-word"
+          minW={0}
+          w="full"
         >
-          <Users /> {event.attendees}/{event.capacity} spots filled
+          <Box flexShrink={0}><Users /></Box>
+          {event.attendees}/{event.capacity} spots filled
         </Text>
       </VStack>
 
@@ -358,7 +382,7 @@ export const EventInfo = ({
         flex="1"
         minH={0}
       >
-        <Text whiteSpace="pre-line">{event.description}</Text>
+        <Text whiteSpace="pre-line" wordBreak="break-word">{event.description}</Text>
       </Box>
 
       {/* Register Button */}
@@ -426,7 +450,7 @@ export const EventInfo = ({
                   <Dialog.Header>
                     <Dialog.Title>Unregister from event?</Dialog.Title>
                   </Dialog.Header>
-                  <Dialog.Body>
+                  <Dialog.Body px={{ base: 6, md: 4 }}>
                     <p>
                       At Community Counsel, your role is vital for providing
                       justice for your neighbors. Are you sure you need to

--- a/client/src/components/eventCatalog/eventInfo.jsx
+++ b/client/src/components/eventCatalog/eventInfo.jsx
@@ -54,11 +54,10 @@ export const EventInfo = ({
     }
   }, [showCopyMessage]);
 
-  // Re-check scroll state whenever event changes (new content may or may not overflow)
+  // Re-check scroll state whenever event changes
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    // Reset to top on event change
     el.scrollTop = 0;
     checkScroll(el);
   }, [event]);
@@ -410,7 +409,6 @@ export const EventInfo = ({
         />
       )}
 
-      {/* ── Bottom gradient — shown whenever content is still scrollable below ── */}
       {!scrollState.bottom && (
         <Box
           position="absolute"

--- a/client/src/components/eventCatalog/eventInfo.jsx
+++ b/client/src/components/eventCatalog/eventInfo.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   Badge,
@@ -42,6 +42,8 @@ export const EventInfo = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [showCopyMessage, setShowCopyMessage] = useState(false);
+  const [scrollState, setScrollState] = useState({ top: true, bottom: false });
+  const scrollRef = useRef(null);
 
   useEffect(() => {
     if (showCopyMessage) {
@@ -51,6 +53,27 @@ export const EventInfo = ({
       return () => clearTimeout(timer);
     }
   }, [showCopyMessage]);
+
+  // Re-check scroll state whenever event changes (new content may or may not overflow)
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Reset to top on event change
+    el.scrollTop = 0;
+    checkScroll(el);
+  }, [event]);
+
+  const checkScroll = (el) => {
+    const atTop = el.scrollTop <= 4;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+    setScrollState({ top: atTop, bottom: atBottom });
+  };
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    checkScroll(el);
+  };
 
   const navigate = useNavigate();
 
@@ -182,219 +205,237 @@ export const EventInfo = ({
   return (
     <Flex
       direction="column"
-      py={{ base: 7, md: "50px" }}
-      px={{ base: 4, md: 8 }}
       w="full"
       h="full"
-      justify="space-between"
-      flex="1"
       overflow="hidden"
+      position="relative"
     >
-      <HStack
-        justify="space-between"
-        align="flex-start"
-        mb="20px"
-        gap={3}
-        minW={0}
+      <Box
+        ref={scrollRef}
+        onScroll={handleScroll}
+        overflowY="auto"
+        flex="1"
+        scrollbar="hidden"
+        py={{ base: 7, md: "50px" }}
+        px={{ base: 4, md: 8 }}
       >
-        <Text
-          fontSize={{ base: "20px", md: "26px" }}
-          fontWeight="bold"
-          lineHeight={{ base: "28px", md: "44px" }}
-          letterSpacing="-2.5%"
-          color="#000000"
-          wordBreak="break-word"
-          minW={0}
-          flex="1"
-        >
-          {event.name}
-        </Text>
-
-        {activeTab === "catalog" && (
-          <Box position="relative" flexShrink={0}>
-            <Box
-              position="absolute"
-              bottom="100%"
-              right={0}
-              mb={2}
-              bg="#487C9E"
-              color="whiteAlpha/0"
-              rounded="md"
-              fontWeight={500}
-              fontSize="xs"
-              px={2}
-              py={0.5}
-              whiteSpace="nowrap"
-              zIndex={10}
-              transition="all 0.2s ease-out"
-              opacity={showCopyMessage ? 1 : 0}
-              transform={showCopyMessage ? "translateY(0)" : "translateY(5px)"}
-              pointerEvents="none"
-            >
-              Link copied!
-            </Box>
-
-            <IconButton
-              variant="outline"
-              colorPalette="gray"
-              onClick={handleShare}
-            >
-              <Share />
-            </IconButton>
-          </Box>
-        )}
-      </HStack>
-
-      {/* Event metadata */}
-      <VStack
-        flexShrink={0}
-        align="flex-start"
-        gap="12px"
-        w="full"
-        fontSize="14px"
-        px="4px"
-      >
-        <Text
-          display="flex"
-          alignItems="center"
-          gap="18px"
-          wordBreak="break-word"
-          minW={0}
-          w="full"
-        >
-          <Box flexShrink={0}><CalendarDays /></Box>
-          {event.displayDate}
-        </Text>
-        <Separator
-          w="full"
-          size="xs"
-        />
-        <Text
-          display="flex"
-          alignItems="center"
-          gap="18px"
-          wordBreak="break-word"
-          minW={0}
-          w="full"
-        >
-          <Box flexShrink={0}><CalendarClock /></Box>
-          {event.displayTime}
-        </Text>
-        <Separator
-          w="full"
-          size="xs"
-        />
-        <Flex
-          alignItems="flex-start"
-          gap="18px"
-          w="full"
+        {/* Title + share button */}
+        <HStack
+          justify="space-between"
+          align="flex-start"
+          mb="20px"
+          gap={3}
           minW={0}
         >
-          <Box
-            flexShrink={0}
-            mt="2px"
-          >
-            <MapPin />
-          </Box>
-          <VStack
-            align="flex-start"
-            gap="4px"
+          <Text
+            fontSize={{ base: "20px", md: "26px" }}
+            fontWeight="bold"
+            lineHeight={{ base: "28px", md: "44px" }}
+            letterSpacing="-2.5%"
+            color="#000000"
+            wordBreak="break-word"
+            minW={0}
             flex="1"
+          >
+            {event.name}
+          </Text>
+
+          {activeTab === "catalog" && (
+            <Box position="relative" flexShrink={0}>
+              <Box
+                position="absolute"
+                bottom="100%"
+                right={0}
+                mb={2}
+                bg="#487C9E"
+                color="whiteAlpha/0"
+                rounded="md"
+                fontWeight={500}
+                fontSize="xs"
+                px={2}
+                py={0.5}
+                whiteSpace="nowrap"
+                zIndex={10}
+                transition="all 0.2s ease-out"
+                opacity={showCopyMessage ? 1 : 0}
+                transform={showCopyMessage ? "translateY(0)" : "translateY(5px)"}
+                pointerEvents="none"
+              >
+                Link copied!
+              </Box>
+
+              <IconButton
+                variant="outline"
+                colorPalette="gray"
+                onClick={handleShare}
+              >
+                <Share />
+              </IconButton>
+            </Box>
+          )}
+        </HStack>
+
+        {/* Event metadata */}
+        <VStack
+          flexShrink={0}
+          align="flex-start"
+          gap="12px"
+          w="full"
+          fontSize="14px"
+          px="4px"
+        >
+          <Text
+            display="flex"
+            alignItems="center"
+            gap="18px"
+            wordBreak="break-word"
+            minW={0}
+            w="full"
+          >
+            <Box flexShrink={0}><CalendarDays /></Box>
+            {event.displayDate}
+          </Text>
+          <Separator w="full" size="xs" />
+          <Text
+            display="flex"
+            alignItems="center"
+            gap="18px"
+            wordBreak="break-word"
+            minW={0}
+            w="full"
+          >
+            <Box flexShrink={0}><CalendarClock /></Box>
+            {event.displayTime}
+          </Text>
+          <Separator w="full" size="xs" />
+          <Flex
+            alignItems="flex-start"
+            gap="18px"
+            w="full"
             minW={0}
           >
-            <Text lineHeight="1.4" wordBreak="break-word">{localityLine}</Text>
-            {showMeetingLink ? (
-              <Text
-                as="a"
-                href={meetingLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                color="#2563EB"
-                fontSize="13px"
-                fontWeight={500}
-                textDecoration="underline"
-                wordBreak="break-all"
-              >
-                Meeting link
-              </Text>
-            ) : null}
-          </VStack>
-        </Flex>
-        <Separator
-          w="full"
-          size="xs"
-        />
-        <Text
-          display="flex"
-          alignItems="center"
-          gap="18px"
-          wordBreak="break-word"
-          minW={0}
-          w="full"
-        >
-          <Box flexShrink={0}><Users /></Box>
-          {event.attendees}/{event.capacity} spots filled
-        </Text>
-      </VStack>
-
-      {/* Event tags */}
-      <HStack
-        flexShrink={0}
-        flexWrap="wrap"
-        my={6}
-        fontSize="12px"
-        fontWeight={500}
-        gap="10px"
-      >
-        {activeTab === "my" && (
-          <RegStatus
-            statusColor={statusColor}
-            statusLabel={statusLabel}
-          />
-        )}
-        {[
-          event.type,
-          ...event.tags,
-          locationTypeTag,
-          ...event.languages,
-        ]
-          .filter(Boolean)
-          .map((item, i) => (
-          <Badge
-            key={i}
-            variant="solid"
-            border="1px solid #E4E4E7"
-            color="#27272A"
-            bg="#F4F4F5"
-            px="10px"
-            py="4px"
+            <Box flexShrink={0} mt="2px">
+              <MapPin />
+            </Box>
+            <VStack align="flex-start" gap="4px" flex="1" minW={0}>
+              <Text lineHeight="1.4" wordBreak="break-word">{localityLine}</Text>
+              {showMeetingLink ? (
+                <Text
+                  as="a"
+                  href={meetingLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="#2563EB"
+                  fontSize="13px"
+                  fontWeight={500}
+                  textDecoration="underline"
+                  wordBreak="break-all"
+                >
+                  Meeting link
+                </Text>
+              ) : null}
+            </VStack>
+          </Flex>
+          <Separator w="full" size="xs" />
+          <Text
+            display="flex"
+            alignItems="center"
+            gap="18px"
+            wordBreak="break-word"
+            minW={0}
+            w="full"
           >
-            {item}
-          </Badge>
-        ))}
-      </HStack>
+            <Box flexShrink={0}><Users /></Box>
+            {event.attendees}/{event.capacity} spots filled
+          </Text>
+        </VStack>
 
-      {/* Event description */}
-      <Box
-        w="full"
-        overflowY="auto"
-        scrollbar="hidden"
-        flex="1"
-        minH={0}
-      >
-        <Text whiteSpace="pre-line" wordBreak="break-word">{event.description}</Text>
+        {/* Event tags */}
+        <HStack
+          flexShrink={0}
+          flexWrap="wrap"
+          my={6}
+          fontSize="12px"
+          fontWeight={500}
+          gap="10px"
+        >
+          {activeTab === "my" && (
+            <RegStatus
+              statusColor={statusColor}
+              statusLabel={statusLabel}
+            />
+          )}
+          {[
+            event.type,
+            ...event.tags,
+            locationTypeTag,
+            ...event.languages,
+          ]
+            .filter(Boolean)
+            .map((item, i) => (
+            <Badge
+              key={i}
+              variant="solid"
+              border="1px solid #E4E4E7"
+              color="#27272A"
+              bg="#F4F4F5"
+              px="10px"
+              py="4px"
+            >
+              {item}
+            </Badge>
+          ))}
+        </HStack>
+
+        {/* Event description */}
+        <Text whiteSpace="pre-line" wordBreak="break-word">
+          {event.description}
+        </Text>
+
+        <Box h="24px" />
       </Box>
 
-      {/* Register Button */}
+      {!scrollState.top && (
+        <Box
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          height="80px"
+          bgGradient="to-b"
+          gradientFrom="white"
+          gradientTo="transparent"
+          pointerEvents="none"
+          zIndex={1}
+        />
+      )}
+
+      {/* ── Bottom gradient — shown whenever content is still scrollable below ── */}
+      {!scrollState.bottom && (
+        <Box
+          position="absolute"
+          bottom="60px"
+          left={0}
+          right={0}
+          height="80px"
+          bgGradient="to-b"
+          gradientFrom="transparent"
+          gradientTo="white"
+          pointerEvents="none"
+          zIndex={1}
+        />
+      )}
+
       <Flex
         flexShrink={0}
         direction="column"
         align="center"
         justify="center"
-        alignSelf="center"
         zIndex={2}
-        mt={3}
-        mb={{ base: 5, md: 1 }}
+        bg="white"
+        pb={{ base: 5, md: 4 }}
+        pt={2}
+        px={{ base: 4, md: 8 }}
       >
         {isPastEvent ? (
           <Button
@@ -477,19 +518,6 @@ export const EventInfo = ({
           </Dialog.Root>
         )}
       </Flex>
-
-      {/* Gradient overlay - fixed at bottom */}
-      <Box
-        position="absolute"
-        bottom={0}
-        left={0}
-        right={0}
-        height="40%"
-        bgGradient="to-b"
-        gradientFrom="transparent"
-        gradientTo="white"
-        pointerEvents="none"
-      />
     </Flex>
   );
 };

--- a/client/src/components/eventCatalog/eventInfo.jsx
+++ b/client/src/components/eventCatalog/eventInfo.jsx
@@ -136,7 +136,7 @@ export const EventInfo = ({
             <Button
               bg="#487C9E"
               p={6}
-              onClick={() => navigate("/all-events")}
+              onClick={() => navigate("/event-catalog/all-events")}
             >
               <LuCalendarDays />
               View All Events

--- a/client/src/components/eventCatalog/eventInfo.jsx
+++ b/client/src/components/eventCatalog/eventInfo.jsx
@@ -217,6 +217,7 @@ export const EventInfo = ({
         scrollbar="hidden"
         py={{ base: 7, md: "50px" }}
         px={{ base: 4, md: 8 }}
+        bg = "white"
       >
         {/* Title + share button */}
         <HStack
@@ -247,7 +248,7 @@ export const EventInfo = ({
                 right={0}
                 mb={2}
                 bg="#487C9E"
-                color="whiteAlpha/0"
+                color="white"
                 rounded="md"
                 fontWeight={500}
                 fontSize="xs"

--- a/client/src/components/eventCatalog/eventsList.jsx
+++ b/client/src/components/eventCatalog/eventsList.jsx
@@ -21,7 +21,10 @@ export const EventsList = ({ events, onSelect, selectedEvent }) => {
             gap="8px"
             borderWidth="1px"
             borderStyle="solid"
-            borderColor={isSelected ? "#3B82F6" : "#E5E7EB"}
+            borderColor={{
+              base: "#E5E7EB",
+              md: isSelected ? "#3B82F6" : "#E5E7EB",
+            }}
             borderRadius="8px"
             bg="white"
             textAlign="left"
@@ -30,7 +33,10 @@ export const EventsList = ({ events, onSelect, selectedEvent }) => {
             _hover={{ bg: "#F9FAFB" }}
             _focus={{ outline: "none" }}
             _focusVisible={{ outline: "none" }}
-            boxShadow={isSelected ? "0 0 0 1px #3B82F6" : "none"}
+            boxShadow={{
+              base: "none",
+              md: isSelected ? "0 0 0 1px #3B82F6" : "none",
+            }}
             onClick={() => onSelect(event)}
             transition="all 0.15s ease"
           >

--- a/client/src/components/eventCatalog/filterTag.jsx
+++ b/client/src/components/eventCatalog/filterTag.jsx
@@ -5,15 +5,23 @@ const FilterTag = ({ label, onRemove }) => {
   return (
     <Box
       bg="#F3F4F6"
-      borderRadius="10px"
-      px="14px"
-      py="10px"
-      minH="44px"
+      borderRadius="sm"
+      px={2}
+      py={1}
       transition="background 0.15s"
       _hover={{ bg: "#E5E7EB" }}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      minH="2rem"
     >
-      <HStack gap="10px">
-        <Text color="#111827" fontSize="15px" fontWeight={500}>
+      <HStack gap={1} align="center">
+        <Text
+          color="#111827"
+          fontSize="sm"
+          fontWeight="500"
+          lineHeight="1"
+        >
           {label}
         </Text>
 
@@ -21,16 +29,15 @@ const FilterTag = ({ label, onRemove }) => {
           aria-label={`Remove ${label}`}
           onClick={onRemove}
           variant="ghost"
-          size="sm"
-          minW="24px"
-          h="24px"
+          size="xs"
           p={0}
+          minW="auto"
+          h="auto"
           borderRadius="full"
-          cursor="pointer"
           color="#6B7280"
           _hover={{ bg: "#D1D5DB", color: "#111827" }}
         >
-          <X size={18} />
+          <X size={14} />
         </IconButton>
       </HStack>
     </Box>

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -92,10 +92,10 @@ const FilterCategory = ({
 export const SortAndFilter = ({
   open,
   onOpenChange,
-  setSortBy,
   selectedFilters,
   setSelectedFilters,
   filteredCount,
+  onApplyFilters,
 }) => {
   const { backend } = useBackendContext();
 
@@ -130,7 +130,6 @@ export const SortAndFilter = ({
         {
           label: "Location",
           key: "locations",
-          // ids must match clinics.location_type enum (API normalizes legacy labels)
           options: [
             { id: "hybrid", text: "Hybrid" },
             { id: "in-person", text: "In-person" },
@@ -169,7 +168,17 @@ export const SortAndFilter = ({
 
   const clearAll = () => {
     setSelectedFilters([]);
-    setSortBy("upcoming");
+  };
+
+  const handleApply = () => {
+    onApplyFilters();
+    onOpenChange(false);
+  };
+
+  const handleClose = () => {
+    clearAll();
+    onApplyFilters();
+    onOpenChange(false);
   };
 
   return (
@@ -204,7 +213,8 @@ export const SortAndFilter = ({
                 </Text>
                 <CloseButton
                   size="sm"
-                  onClick={() => onOpenChange(false)}
+                  onClick={handleClose}
+
                 />
               </Flex>
             </Drawer.Header>
@@ -330,8 +340,8 @@ export const SortAndFilter = ({
                   fontWeight={500}
                   size="xl"
                   _hover={{ bg: "#5c86a3" }}
-                  onClick={() => onOpenChange(false)}
-                  isDisabled={selectedFilters.length === 0 || filteredCount === 0}
+                  onClick={handleApply}
+                  disabled={selectedFilters.length === 0 || filteredCount === 0}
                 >
                   <ListFilter size={20} />
                   {selectedFilters.length === 0

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -304,32 +304,31 @@ export const SortAndFilter = ({
               borderColor="#E5E7EB"
             >
               <Flex
-                justify="space-between"
-                align="center"
                 w="100%"
+                gap="12px"
               >
                 <Button
+                  flex={1}
                   variant="outline"
                   borderColor="#D1D5DB"
                   color="#374151"
                   fontSize="14px"
                   fontWeight={500}
                   size="xl"
-                  px="20px"
-                  py="2px"
                   _hover={{ bg: "#F9FAFB" }}
                   onClick={clearAll}
                 >
                   Clear
                 </Button>
+
                 <Button
+                  flex={2}
+                  minW="fit-content"
                   bg="#487C9E"
                   color="white"
                   fontSize="14px"
                   fontWeight={500}
                   size="xl"
-                  px="20px"
-                  py="2px"
                   _hover={{ bg: "#5c86a3" }}
                   onClick={() => onOpenChange(false)}
                   disabled={filteredCount === 0}

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -101,6 +101,8 @@ export const SortAndFilter = ({
 
   const [filterCategories, setFilterCategories] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [first, setFirst] = useState(true);
 
   const fetchFilterOptions = async () => {
     try {
@@ -159,6 +161,7 @@ export const SortAndFilter = ({
   }, []);
 
   const toggleFilter = (option) => {
+    if (first) setFirst(false);
     setSelectedFilters((prev) =>
       prev.some((f) => f.id === option.id)
         ? prev.filter((f) => f.id !== option.id)
@@ -171,8 +174,10 @@ export const SortAndFilter = ({
   };
 
   const handleApply = () => {
+    setApplying(true);
     onApplyFilters();
     onOpenChange(false);
+    setApplying(false);
   };
 
   const handleClose = () => {
@@ -214,7 +219,6 @@ export const SortAndFilter = ({
                 <CloseButton
                   size="sm"
                   onClick={handleClose}
-
                 />
               </Flex>
             </Drawer.Header>
@@ -341,13 +345,13 @@ export const SortAndFilter = ({
                   size="xl"
                   _hover={{ bg: "#5c86a3" }}
                   onClick={handleApply}
-                  disabled={selectedFilters.length === 0 || filteredCount === 0}
+                  disabled={first || filteredCount === 0}
                 >
                   <ListFilter size={20} />
-                  {selectedFilters.length === 0
-                    ? `Seeing ${filteredCount} Results`
+                  {selectedFilters.length === 0 && filteredCount === 0
+                    ? `See ${filteredCount} Results`
                     : filteredCount > 0
-                      ? `See ${filteredCount} Results`
+                      ? `See ${filteredCount} ${filteredCount === 1 ? "Result" : "Results"}`
                       : "No Results"}
                 </Button>
               </Flex>

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -102,7 +102,6 @@ export const SortAndFilter = ({
 
   const [filterCategories, setFilterCategories] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [applying, setApplying] = useState(false);
   const [first, setFirst] = useState(true);
 
   const isUnchanged = useMemo(() => {
@@ -181,15 +180,12 @@ export const SortAndFilter = ({
   };
 
   const handleApply = () => {
-    setApplying(true);
     onApplyFilters();
     onOpenChange(false);
-    setApplying(false);
   };
 
   const handleClose = () => {
-    clearAll();
-    onApplyFilters();
+    setSelectedFilters(appliedFilters);
     onOpenChange(false);
   };
 

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -331,12 +331,14 @@ export const SortAndFilter = ({
                   size="xl"
                   _hover={{ bg: "#5c86a3" }}
                   onClick={() => onOpenChange(false)}
-                  disabled={filteredCount === 0}
+                  isDisabled={selectedFilters.length === 0 || filteredCount === 0}
                 >
                   <ListFilter size={20} />
-                  {filteredCount > 0
-                    ? `See ${filteredCount} Results`
-                    : "No Results"}
+                  {selectedFilters.length === 0
+                    ? `Seeing ${filteredCount} Results`
+                    : filteredCount > 0
+                      ? `See ${filteredCount} Results`
+                      : "No Results"}
                 </Button>
               </Flex>
             </Drawer.Footer>

--- a/client/src/components/eventCatalog/sortAndFilter.jsx
+++ b/client/src/components/eventCatalog/sortAndFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import {
   Box,
@@ -96,6 +96,7 @@ export const SortAndFilter = ({
   setSelectedFilters,
   filteredCount,
   onApplyFilters,
+  appliedFilters,
 }) => {
   const { backend } = useBackendContext();
 
@@ -103,6 +104,12 @@ export const SortAndFilter = ({
   const [isLoading, setIsLoading] = useState(true);
   const [applying, setApplying] = useState(false);
   const [first, setFirst] = useState(true);
+
+  const isUnchanged = useMemo(() => {
+    if (selectedFilters.length !== appliedFilters.length) return false;
+    const appliedIds = new Set(appliedFilters.map((f) => f.id));
+    return selectedFilters.every((f) => appliedIds.has(f.id));
+  }, [selectedFilters, appliedFilters]);
 
   const fetchFilterOptions = async () => {
     try {
@@ -345,7 +352,7 @@ export const SortAndFilter = ({
                   size="xl"
                   _hover={{ bg: "#5c86a3" }}
                   onClick={handleApply}
-                  disabled={first || filteredCount === 0}
+                  disabled={first || filteredCount === 0 || isUnchanged}
                 >
                   <ListFilter size={20} />
                   {selectedFilters.length === 0 && filteredCount === 0

--- a/client/src/components/eventCatalog/topBar.jsx
+++ b/client/src/components/eventCatalog/topBar.jsx
@@ -24,6 +24,7 @@ export const TopBar = ({
   selectedFilters,
   setSelectedFilters,
   filteredCount,
+  onApplyFilters,
   events,
 }) => {
   const isMobile = useBreakpointValue({ base: true, md: false });
@@ -38,6 +39,12 @@ export const TopBar = ({
   }, [selectedFilters]);
 
   const showSearch = !isMobile || !showDetails;
+
+  // Removes a chip and immediately re-fetches with the updated filters
+  const handleRemoveFilter = (updatedFilters) => {
+    setSelectedFilters(updatedFilters);
+    onApplyFilters();
+  };
 
   return (
     <Flex
@@ -173,6 +180,7 @@ export const TopBar = ({
             selectedFilters={selectedFilters}
             setSelectedFilters={setSelectedFilters}
             filteredCount={filteredCount}
+            onApplyFilters={onApplyFilters}
           />
 
           <SearchBar
@@ -188,7 +196,7 @@ export const TopBar = ({
       {showSearch && (
         <AppliedFilters
           selectedFilters={selectedFilters}
-          setSelectedFilters={setSelectedFilters}
+          setSelectedFilters={handleRemoveFilter}
         />
       )}
     </Flex>

--- a/client/src/components/eventCatalog/topBar.jsx
+++ b/client/src/components/eventCatalog/topBar.jsx
@@ -29,20 +29,24 @@ export const TopBar = ({
 }) => {
   const isMobile = useBreakpointValue({ base: true, md: false });
   const [filterOpen, setFilterOpen] = useState(false);
+  const [appliedFilters, setAppliedFilters] = useState([]);
 
   const hasAppliedFilters = useMemo(() => {
-    if (!selectedFilters) return false;
-    return Object.values(selectedFilters).some((value) => {
-      if (Array.isArray(value)) return value.length > 0;
-      return value !== null && value !== undefined && value !== "";
-    });
-  }, [selectedFilters]);
+    return appliedFilters.length > 0;
+  }, [appliedFilters]);
 
   const showSearch = !isMobile || !showDetails;
 
-  // Removes a chip and immediately re-fetches with the updated filters
+  // Snapshots selected filters into appliedFilters and triggers the fetch
+  const handleApply = () => {
+    setAppliedFilters(selectedFilters);
+    onApplyFilters();
+  };
+
+  // Removes a chip, updates both states, and immediately re-fetches
   const handleRemoveFilter = (updatedFilters) => {
     setSelectedFilters(updatedFilters);
+    setAppliedFilters(updatedFilters);
     onApplyFilters();
   };
 
@@ -180,7 +184,7 @@ export const TopBar = ({
             selectedFilters={selectedFilters}
             setSelectedFilters={setSelectedFilters}
             filteredCount={filteredCount}
-            onApplyFilters={onApplyFilters}
+            onApplyFilters={handleApply}
           />
 
           <SearchBar
@@ -192,10 +196,10 @@ export const TopBar = ({
         </Flex>
       )}
 
-      {/* Applied filter chips row - returns null when no filters active */}
+      {/* Applied filter chips row - renders based on committed filters only */}
       {showSearch && (
         <AppliedFilters
-          selectedFilters={selectedFilters}
+          selectedFilters={appliedFilters}
           setSelectedFilters={handleRemoveFilter}
         />
       )}

--- a/client/src/components/eventCatalog/topBar.jsx
+++ b/client/src/components/eventCatalog/topBar.jsx
@@ -37,9 +37,12 @@ export const TopBar = ({
 
   const showSearch = !isMobile || !showDetails;
 
-  // Snapshots selected filters into appliedFilters and triggers the fetch
-  const handleApply = () => {
-    setAppliedFilters(selectedFilters);
+  // Snapshots selected filters into appliedFilters and triggers the fetch.
+  // Takes the filters explicitly rather than only reading the `selectedFilters`
+  // prop, since a caller may have just queued a setSelectedFilters update in
+  // the same tick (that prop wouldn't reflect it yet on this render).
+  const handleApply = (filtersToApply = selectedFilters) => {
+    setAppliedFilters(filtersToApply);
     onApplyFilters();
   };
 

--- a/client/src/components/eventCatalog/topBar.jsx
+++ b/client/src/components/eventCatalog/topBar.jsx
@@ -185,6 +185,7 @@ export const TopBar = ({
             setSelectedFilters={setSelectedFilters}
             filteredCount={filteredCount}
             onApplyFilters={handleApply}
+            appliedFilters={appliedFilters}
           />
 
           <SearchBar


### PR DESCRIPTION
## Description
Changes made according to Ali/Figma:
* Fixed Event Info panel background color
* Removed blue outline from selected event on mobile view
* Fixed text wraparound for Event title on mobile
* Implemented redirect functionality for View All Events button (My Events tab)
* Padded unregister dialog
* Fixed scroll pane contents and gradient display for EventInfo (created a mock event with a long description to test)
* Made it so page only re-renders upon clicking the See X Results button, while still dynamically updating X by means of a simpler count query
* Button is disabled for duplicate tag sets such that we don't query a result that is already displayed
## Issues
Closes #157 

> [!NOTE]
> * The "Estate" filter currently doesn't match the actual tag ("Estate Planning"), didn't touch this as this is a db thing
> * The one part of the flow that I did not implement was the "Seeing x Results" which is what shows up when seeing the same set (the disabling flow I described above) as when I did do this, there would be an intermediate state that would flash for half a second that was buggy visually




