### PR TITLE
161-volunteer-create-and-login-refinements

### DIFF
--- a/client/src/components/volunteerLogin/steps/BackgroundStep.tsx
+++ b/client/src/components/volunteerLogin/steps/BackgroundStep.tsx
@@ -1,26 +1,36 @@
+import { useEffect, useState } from "react";
+
 import {
   Box,
   Button,
   Flex,
   Heading,
   Input,
+  Link,
   Progress,
   Text,
 } from "@chakra-ui/react";
 
-import { useEffect, useState } from "react";
-
 import { LuArrowRight } from "react-icons/lu";
+import { useNavigate } from "react-router-dom";
 
-import LoginLayout from "./BackgroundLayout";
 import { loadDraft, saveDraft } from "../volunteerSignupDraft";
+import LoginLayout from "./BackgroundLayout";
 
 type Props = {
   onComplete: () => Promise<void>;
   isSubmitting: boolean;
+  submitError?: string | null;
+  onDismissError: () => void;
 };
 
-const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
+const BackgroundStep = ({
+  onComplete,
+  isSubmitting,
+  submitError,
+  onDismissError,
+}: Props) => {
+  const navigate = useNavigate();
   const [gradYear, setGradYear] = useState("");
   const [gradError, setGradError] = useState(false);
   const [employer, setEmployer] = useState("");
@@ -34,6 +44,8 @@ const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
   }, []);
 
   const handleSubmit = async () => {
+    onDismissError();
+
     const isValidYear = /^\d{4}$/.test(gradYear);
 
     if (!isValidYear) {
@@ -132,6 +144,36 @@ const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
               </Progress.Track>
             </Progress.Root>
 
+            {submitError && (
+              <Box
+                w="100%"
+                border="1px solid"
+                borderColor="red.200"
+                bg="red.50"
+                p="10px"
+                borderRadius="8px"
+              >
+                <Text
+                  color="red.700"
+                  fontSize="14px"
+                >
+                  {submitError}
+                </Text>
+                <Link
+                  color="blue.600"
+                  textDecoration="underline"
+                  fontSize="14px"
+                  mt="8px"
+                  display="inline-block"
+                  onClick={() =>
+                    navigate("/login/volunteer", { replace: true })
+                  }
+                >
+                  Go to login
+                </Link>
+              </Box>
+            )}
+
             <Box>
               <Text
                 fontSize={{ base: "13px", md: "16px" }}
@@ -139,7 +181,14 @@ const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
                 mb="8px"
                 fontWeight="bold"
               >
-                Graduation Year <Box as="span" color="#991919"> *</Box>
+                Graduation Year{" "}
+                <Box
+                  as="span"
+                  color="#991919"
+                >
+                  {" "}
+                  *
+                </Box>
               </Text>
               <Input
                 placeholder="20XX"
@@ -169,7 +218,14 @@ const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
                 mb="8px"
                 fontWeight="bold"
               >
-                Employer <Box as="span" color="#991919"> *</Box>
+                Employer{" "}
+                <Box
+                  as="span"
+                  color="#991919"
+                >
+                  {" "}
+                  *
+                </Box>
               </Text>
               <Input
                 placeholder="Enter your company name"
@@ -217,23 +273,27 @@ const BackgroundStep = ({ onComplete, isSubmitting }: Props) => {
               onClick={handleSubmit}
               loading={isSubmitting}
             >
-              <Box w="100%" textAlign="center">
+              <Box
+                w="100%"
+                textAlign="center"
+              >
                 Create Account
               </Box>
-              <Box position="absolute" right="12px">
+              <Box
+                position="absolute"
+                right="12px"
+              >
                 <LuArrowRight size={16} />
               </Box>
             </Button>
-
           </Flex>
         </Flex>
-
         <Box
-          w="100%"
-          h="70px"
-          bg="#F6F6F6"
-          flexShrink={0}
-        />
+        w="100%"
+        h="70px"
+        bg="#F6F6F6"
+        flexShrink={0}
+      />
       </Flex>
     </LoginLayout>
   );

--- a/client/src/components/volunteerLogin/volunteerLogin.tsx
+++ b/client/src/components/volunteerLogin/volunteerLogin.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -93,6 +93,14 @@ export const VolunteerLogin = () => {
     if (n) goToStep(n);
   }, [step, goToStep]);
 
+  const emailAlreadyInUseError = (e: unknown): boolean => {  
+    const err = e as {
+      code?: string;
+      message?: string;
+    };
+    return (err.code === "auth/email-already-in-use") || (err.message?.toLowerCase().includes("email already in use") ?? false);
+  };
+
   const handleCompleteSignup = useCallback(async () => {
     const d = loadDraft();
     if (!d || !hasSignupBasics(d)) {
@@ -111,9 +119,9 @@ export const VolunteerLogin = () => {
         response?: { data?: { message?: string } | string };
         message?: string;
       };
-      if (err.code === "auth/email-already-in-use") {
+      if (emailAlreadyInUseError(e)) {
         setCompleteError(
-          "An account with this email already exists. Please log in."
+          "An account with this email already exists. Please log in instead, or contact support if you believe this is an error."
         );
         return;
       }
@@ -136,20 +144,6 @@ export const VolunteerLogin = () => {
       minH="100vh"
       direction="column"
     >
-      {completeError && step === "background" && (
-        <Text
-          role="alert"
-          px={4}
-          py={2}
-          bg="red.50"
-          color="red.800"
-          fontSize="sm"
-          borderBottomWidth="1px"
-          borderColor="red.200"
-        >
-          {completeError}
-        </Text>
-      )}
       {step === "login" && (
         <LoginStep onNavigateToCreateAccount={() => goToStep("create-account")} />
       )}
@@ -175,6 +169,8 @@ export const VolunteerLogin = () => {
         <BackgroundStep
           onComplete={handleCompleteSignup}
           isSubmitting={isCompleting}
+          submitError={completeError}
+          onDismissError={() => setCompleteError(null)}
         />
       )}
       {step === "success" && (


### PR DESCRIPTION
## Description
Verified the volunteer create and login page's functionality, testing the implementation with Sahana (she loved it!). Discovered and solved an edge case with toasts not properly displaying on the end page when a volunteer creates an invalid account.

## Screenshots/Media

### Added new error detection in volunteerLogin, verifying if the email is already in use based on error code or message contents.
<img width="2355" height="839" alt="image" src="https://github.com/user-attachments/assets/45c13ee7-3a57-4d0e-a6cd-b62321a3904b" />

### Adjusted BackgroundStep Props to take in a submit and dismiss error (to display and remove toast).
<img width="2365" height="1410" alt="image" src="https://github.com/user-attachments/assets/a7fbe92e-4059-400a-ae07-ece45a2d1059" />

###  New Toast (with return link back to login page).
<img width="2250" height="1251" alt="image" src="https://github.com/user-attachments/assets/5c241d43-3078-439a-9eeb-3b26ea71878d" />
<img width="2309" height="1208" alt="image" src="https://github.com/user-attachments/assets/116d9ffb-e2aa-4705-9719-1cfdc0ee5fd9" />

## Issues
- Extreme edge case found preventing both creation and logging in if a user logs using different log-in forms several times (was unable to reproduce exact error, but is likely to do with Firebase with multiple SSOs overriding each other in the database, causing the API endpoint to throw an error).
- This is not in the Figma, but currently the toast pops up at the very end of the create volunteer section, when it would be more UX friendly if it happened immediately after the user sets in their email (on the very second page). Think this would require a new endpoint, though.

Closes #161