### PR TITLE
Slight changes to spacing and editing a template

### DIFF
--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -14,6 +14,7 @@ export const NewTemplateSection = ({
   setTemplateSubject,
   templateContent,
   setTemplateContent,
+  isEditable = true,
 }) => {
   // Rich text editor setup
   const editor = useEditor({
@@ -25,12 +26,19 @@ export const NewTemplateSection = ({
       TextStyleKit,
     ],
     content: templateContent || "<p></p>",
+    editable: isEditable,
     onUpdate: ({ editor }) => {
       setTemplateContent(editor.getHTML());
     },
     shouldRerenderOnTransaction: true,
     immediatelyRender: false,
   });
+
+  useEffect(() => {
+    if (!editor) return;
+
+    editor.setEditable(isEditable);
+  }, [editor, isEditable]);
 
   useEffect(() => {
     if (!editor) return;
@@ -65,10 +73,14 @@ export const NewTemplateSection = ({
               value={templateSubject}
               onChange={(e) => setTemplateSubject(e.target.value)}
               placeholder="Enter subject line"
+              readOnly={!isEditable}
+              cursor={isEditable ? "text" : "default"}
               h="40px"
               borderColor="#E4E4E7"
               borderWidth="1px"
               borderRadius="5px"
+              bg="white"
+              _readOnly={{ bg: "white", opacity: 1, cursor: "default" }}
               _focusVisible={{ borderColor: "#487C9E", boxShadow: "0 0 0 1px #487C9E" }}
             />
           </VStack>
@@ -115,6 +127,7 @@ export const NewTemplateSection = ({
             <Box
               flex="1"
               minH={0}
+              cursor={isEditable ? "text" : "default"}
             >
               <RichTextEditor.Content
                 style={{ height: "100%", minHeight: 0 }}

--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -104,26 +104,28 @@ export const NewTemplateSection = ({
               minHeight: 0,
             }}
           >
-            <RichTextEditor.Toolbar
-              style={{ borderBottom: "1px solid #EFEFF1" }}
-            >
-              <RichTextEditor.ControlGroup>
-                <Control.FontFamily />
-                <Control.FontSize />
-              </RichTextEditor.ControlGroup>
-              <RichTextEditor.ControlGroup>
-                <Control.Bold />
-                <Control.Italic />
-                <Control.Underline />
-                <Control.Strikethrough />
-              </RichTextEditor.ControlGroup>
-              <RichTextEditor.ControlGroup>
-                <Control.H1 />
-                <Control.H2 />
-                <Control.H3 />
-                <Control.H4 />
-              </RichTextEditor.ControlGroup>
-            </RichTextEditor.Toolbar>
+            {isEditable && (
+              <RichTextEditor.Toolbar
+                style={{ borderBottom: "1px solid #EFEFF1" }}
+              >
+                <RichTextEditor.ControlGroup>
+                  <Control.FontFamily />
+                  <Control.FontSize />
+                </RichTextEditor.ControlGroup>
+                <RichTextEditor.ControlGroup>
+                  <Control.Bold />
+                  <Control.Italic />
+                  <Control.Underline />
+                  <Control.Strikethrough />
+                </RichTextEditor.ControlGroup>
+                <RichTextEditor.ControlGroup>
+                  <Control.H1 />
+                  <Control.H2 />
+                  <Control.H3 />
+                  <Control.H4 />
+                </RichTextEditor.ControlGroup>
+              </RichTextEditor.Toolbar>
+            )}
             <Box
               flex="1"
               minH={0}

--- a/client/src/components/emailTemplateManagement/components/RenameFolderDialog.jsx
+++ b/client/src/components/emailTemplateManagement/components/RenameFolderDialog.jsx
@@ -7,17 +7,20 @@ import { Pencil } from "lucide-react";
  * The trigger is just an icon — no labelled button — so it sits cleanly
  * next to the folder title text (matching Figma 1519-83577).
  */
-export const RenameFolderDialog = ({ folderName = "", onRename }) => {
+export const RenameFolderDialog = ({ folderName = "", onRename, setIsRenaming }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
 
   const handleOpen = () => {
     setInputValue(folderName);
+    setIsRenaming?.(true);
     setIsOpen(true);
   };
 
   const handleOpenChange = ({ open }) => {
     setIsOpen(open);
+    setIsRenaming?.(open);
+
     if (!open) setInputValue("");
   };
 
@@ -25,6 +28,7 @@ export const RenameFolderDialog = ({ folderName = "", onRename }) => {
     if (!inputValue.trim()) return;
     onRename(inputValue.trim());
     setIsOpen(false);
+    setIsRenaming?.(false);
     setInputValue("");
   };
 

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -45,9 +45,9 @@ export const EmailTemplateManagement = () => {
   const [itemsPerPage, setItemsPerPage] = useState(7);
   const listContainerRef = useRef(null);
   // dynamic listing based on browswer size
-  // card height: py=15*2 + lineHeight=24 + border=2 = 56px; gap between cards = 16px
+  // card height: py=15*2 + lineHeight=24 + border=2 = 56px; gap between cards = 30px
   const CARD_HEIGHT = 56;
-  const CARD_GAP = 16;
+  const CARD_GAP = 30;
 
   useEffect(() => {
     const el = listContainerRef.current;
@@ -108,7 +108,11 @@ export const EmailTemplateManagement = () => {
   // inline title editing
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editingTitleValue, setEditingTitleValue] = useState("");
+  const [isEditingTemplate, setIsEditingTemplate] = useState(false);
   const titleInputRef = useRef(null);
+
+  const isTemplateEditable =
+    isEditingTemplate || isNewTemplate || urlTemplateId?.startsWith("new-");
 
   // derive currentFolder from URL params
   const activeFolderId = urlFolderId || folderIdFromQuery;
@@ -168,6 +172,7 @@ export const EmailTemplateManagement = () => {
       if (urlTemplateId) {
         // skip fetching for new unsaved templates (temp IDs start with 'new-')
         if (urlTemplateId.startsWith('new-')) {
+          setIsEditingTemplate(true);
           return;
         }
         try {
@@ -184,6 +189,7 @@ export const EmailTemplateManagement = () => {
             content,
           });
           setIsNewTemplate(false);
+          setIsEditingTemplate(false);
         } catch (error) {
           console.error('Error fetching template:', error);
           // navigate back to folders if template not found
@@ -303,6 +309,7 @@ export const EmailTemplateManagement = () => {
     });
     setCurrentTemplateId(null);
     setIsNewTemplate(false);
+    setIsEditingTemplate(false);
   };
 
   const normalizeEditorContent = useCallback((content = "") => {
@@ -323,6 +330,8 @@ export const EmailTemplateManagement = () => {
     initialTemplateSnapshot,
     normalizeEditorContent,
   ]);
+
+  const showEditModeDeleteButton = isEditingTemplate && !hasUnsavedChanges;
 
   const openMoveTemplateModalWithDefaultFolder = () => {
     const firstAvailableFolder = folders.find(
@@ -387,6 +396,8 @@ export const EmailTemplateManagement = () => {
       if (shouldOpenMoveModal) {
         openMoveTemplateModalWithDefaultFolder();
       }
+
+      setIsEditingTemplate(false);
     } catch (error) {
       alert("Failed to save template. Please try again.");
     }
@@ -434,6 +445,7 @@ export const EmailTemplateManagement = () => {
         subject: "",
         content,
       });
+      setIsEditingTemplate(true);
       setShowFolderViewTemplatePopover(false);
       navigate(`/email/template/${createdTemplate.id}?folderId=${currentFolder.id}`);
     } catch (error) {
@@ -482,6 +494,7 @@ export const EmailTemplateManagement = () => {
           content: "",
         });
         setIsNewTemplate(false);
+        setIsEditingTemplate(true);
         setShowNewTemplatePopover(false);
         navigate(`/email/template/${createdTemplate.id}?folderId=${currentFolder.id}`);
       } else {
@@ -498,6 +511,7 @@ export const EmailTemplateManagement = () => {
           content: "",
         });
         setIsNewTemplate(true);
+        setIsEditingTemplate(true);
         setShowNewTemplatePopover(false);
         navigate(`/email/template/${tempId}`);
       }
@@ -982,12 +996,16 @@ export const EmailTemplateManagement = () => {
                       fontSize="3xl"
                       fontWeight="600"
                       lineHeight="1.2"
-                      cursor="text"
-                      onDoubleClick={() => {
-                        setEditingTitleValue(templateName);
-                        setIsEditingTitle(true);
-                      }}
-                      title="Double-click to rename"
+                      cursor={isTemplateEditable ? "text" : "default"}
+                      onDoubleClick={
+                        isTemplateEditable
+                          ? () => {
+                              setEditingTitleValue(templateName);
+                              setIsEditingTitle(true);
+                            }
+                          : undefined
+                      }
+                      title={isTemplateEditable ? "Double-click to rename" : undefined}
                     >
                       {templateName}
                     </Text>
@@ -1036,17 +1054,7 @@ export const EmailTemplateManagement = () => {
                         await handleSaveButtonClick();
                         return;
                       }
-                      try {
-                        const templateIdToCheck =
-                          currentTemplateId ||
-                          (urlTemplateId && !urlTemplateId.startsWith("new-") ? urlTemplateId : null);
-                        const shouldOpenMoveModal = await hasNoLinkedFolders(templateIdToCheck);
-                        if (shouldOpenMoveModal) {
-                          openMoveTemplateModalWithDefaultFolder();
-                        }
-                      } catch (error) {
-                        // don't block user flow on lookup errors
-                      }
+                      setIsEditingTemplate((prev) => !prev);
                     }}
                   >
                     {hasUnsavedChanges ? <Save size={16} /> : <Pencil size={16} />}
@@ -1054,11 +1062,44 @@ export const EmailTemplateManagement = () => {
                   </Button>
 
                   <Button
-                    variant="outline"
-                    color={showMoveTemplateModal || showRenameDialog ? "black" : "#991919"}
-                    borderColor={showMoveTemplateModal || showRenameDialog ? "#E4E4E7" : "#FECACA"}
-                    bg={showMoveTemplateModal || showRenameDialog ? "#E4E4E7" : "transparent"}
-                    _hover={showMoveTemplateModal || showRenameDialog ? { bg: "#E4E4E7" } : { bg: "#FEE2E2" }}
+                    variant={showEditModeDeleteButton ? "solid" : "outline"}
+                    h="40px"
+                    px="16px"
+                    fontSize="14px"
+                    fontWeight="500"
+                    borderRadius="4px"
+                    borderWidth="1px"
+                    display="flex"
+                    gap="8px"
+                    alignItems="center"
+                    color={
+                      showEditModeDeleteButton
+                        ? "#18181B"
+                        : showMoveTemplateModal || showRenameDialog
+                          ? "black"
+                          : "#991919"
+                    }
+                    borderColor={
+                      showEditModeDeleteButton
+                        ? "#E4E4E7"
+                        : showMoveTemplateModal || showRenameDialog
+                          ? "#E4E4E7"
+                          : "#FECACA"
+                    }
+                    bg={
+                      showEditModeDeleteButton
+                        ? "#E4E4E7"
+                        : showMoveTemplateModal || showRenameDialog
+                          ? "#E4E4E7"
+                          : "transparent"
+                    }
+                    _hover={
+                      showEditModeDeleteButton
+                        ? { bg: "#E4E4E7" }
+                        : showMoveTemplateModal || showRenameDialog
+                          ? { bg: "#E4E4E7" }
+                          : { bg: "#FEE2E2" }
+                    }
                     onClick={() => setShowDeleteModal(true)}
                   >
                     <Trash2 size={16} />
@@ -1072,7 +1113,7 @@ export const EmailTemplateManagement = () => {
 
         {/* Folder List View */}
         {view === "folders" && (
-          <VStack ref={listContainerRef} align="stretch" spacing={4} mb={8} flex="1" overflow="hidden">
+          <VStack ref={listContainerRef} align="stretch" gap="30px" mb={8} flex="1" overflow="hidden">
             {isLoadingFolders ? (
               <Text>Loading folders...</Text>
             ) : folders.length === 0 ? (
@@ -1104,7 +1145,7 @@ export const EmailTemplateManagement = () => {
                 onCreateTemplate={handleCreateTemplateFromFolderView}
               />
             ) : (
-              <VStack align="stretch" spacing={4} width="100%">
+              <VStack align="stretch" gap="30px" width="100%">
                 {paginatedTemplates.map((template) => (
                   <TemplateCard
                     key={template.id}
@@ -1129,6 +1170,7 @@ export const EmailTemplateManagement = () => {
               setTemplateSubject={setTemplateSubject}
               templateContent={templateContent}
               setTemplateContent={setTemplateContent}
+              isEditable={isTemplateEditable}
             />
           </Box>
         )}

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -870,7 +870,6 @@ export const EmailTemplateManagement = () => {
                   <RenameFolderDialog
                     folderName={currentFolder.name}
                     onRename={handleRenameFolder}
-                    isRenaming={isRenamingFolder}
                     setIsRenaming={setIsRenamingFolder}
                   />
                 )}
@@ -905,17 +904,20 @@ export const EmailTemplateManagement = () => {
                       px: "16px",
                       fontWeight: "500",
                       disabled: isRenamingFolder,
-                      backgroundColor: isRenamingFolder ? "#E4E4E7" : "#487C9E",
-                      color: isRenamingFolder ? "#71717A" : "white",
-                      _hover: isRenamingFolder ? { bg: "#E4E4E7" } : { bg: "#294A5F" },
-
-                      ...(showDeleteFolderModal
+                      ...(isRenamingFolder
                         ? {
-                            backgroundColor: "#E4E4E7",
-                            color: "black",
-                            _hover: { bg: "#E4E4E7" },
+                            backgroundColor: "#D4D4D8",
+                            color: "#18181B",
+                            borderColor: "#D4D4D8",
+                            _hover: { bg: "#D4D4D8" },
                           }
-                        : {}),
+                        : showDeleteFolderModal
+                          ? {
+                              backgroundColor: "#E4E4E7",
+                              color: "black",
+                              _hover: { bg: "#E4E4E7" },
+                            }
+                          : {}),
                     }}
                   />
                 )}

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -107,6 +107,7 @@ export const EmailTemplateManagement = () => {
 
   // inline title editing
   const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isRenamingFolder, setIsRenamingFolder] = useState(false);
   const [editingTitleValue, setEditingTitleValue] = useState("");
   const [isEditingTemplate, setIsEditingTemplate] = useState(false);
   const titleInputRef = useRef(null);
@@ -869,6 +870,8 @@ export const EmailTemplateManagement = () => {
                   <RenameFolderDialog
                     folderName={currentFolder.name}
                     onRename={handleRenameFolder}
+                    isRenaming={isRenamingFolder}
+                    setIsRenaming={setIsRenamingFolder}
                   />
                 )}
               </Flex>
@@ -881,7 +884,7 @@ export const EmailTemplateManagement = () => {
                       isOpen={showNewTemplatePopover}
                       onOpenChange={setShowNewTemplatePopover}
                       onSubmit={handleCreateTemplateFromPopover}
-                      buttonProps={{ h: "40px", fontSize: "14px", px: "16px", fontWeight: "500" }}
+                      buttonProps={{ h: "40px", fontSize: "14px", px: "16px", fontWeight: "500"}}
                     />
                     <NewFolderPopover
                       isOpen={showNewFolderPopover}
@@ -901,6 +904,11 @@ export const EmailTemplateManagement = () => {
                       fontSize: "14px",
                       px: "16px",
                       fontWeight: "500",
+                      disabled: isRenamingFolder,
+                      backgroundColor: isRenamingFolder ? "#E4E4E7" : "#487C9E",
+                      color: isRenamingFolder ? "#71717A" : "white",
+                      _hover: isRenamingFolder ? { bg: "#E4E4E7" } : { bg: "#294A5F" },
+
                       ...(showDeleteFolderModal
                         ? {
                             backgroundColor: "#E4E4E7",
@@ -914,15 +922,17 @@ export const EmailTemplateManagement = () => {
                 {view === "folderView" && 
                   (templates.length === 0 ?
                     <Button
-                      bg="#DC2626"
-                      color="white"
+                      disabled={isRenamingFolder}
+                      bg={isRenamingFolder ? "#E4E4E7" : "#DC2626"}
+                      color={isRenamingFolder ? "#71717A" : "white"}
                       h="40px"
                       px="16px"
                       fontSize="14px"
                       fontWeight="500"
                       borderRadius="4px"
                       borderWidth="1px"
-                      borderColor="#DC2626"
+                      borderColor={isRenamingFolder ? "#E4E4E7" : "#DC2626"}
+                      _hover={isRenamingFolder ? { bg: "#E4E4E7" } : { bg: "#B91C1C" }}
                       onClick={() => setShowDeleteFolderModal(true)}
                       display="flex"
                       gap="8px"
@@ -933,16 +943,35 @@ export const EmailTemplateManagement = () => {
                     </Button>
                   :
                     <Button
-                      bg={showNewTemplatePopover ? "#E4E4E7" : "white"}
-                      color={showNewTemplatePopover ? "black" : "#991919"}
+                      disabled={isRenamingFolder}
+                      bg={
+                        isRenamingFolder || showNewTemplatePopover
+                          ? "#E4E4E7"
+                          : "white"
+                      }
+                      color={
+                        isRenamingFolder
+                          ? "#71717A"
+                          : showNewTemplatePopover
+                            ? "black"
+                            : "#991919"
+                      }
                       h="40px"
                       px="16px"
                       fontSize="14px"
                       fontWeight="500"
                       borderRadius="4px"
                       borderWidth="1px"
-                      borderColor={showNewTemplatePopover ? "#E4E4E7" : "#FECACA"}
-                      _hover={showNewTemplatePopover ? { bg: "#E4E4E7" } : { bg: "#FEE2E2" }}
+                      borderColor={
+                        isRenamingFolder || showNewTemplatePopover
+                          ? "#E4E4E7"
+                          : "#FECACA"
+                      }
+                      _hover={
+                        isRenamingFolder || showNewTemplatePopover
+                          ? { bg: "#E4E4E7" }
+                          : { bg: "#FEE2E2" }
+                      }
                       onClick={() => setShowDeleteFolderModal(true)}
                       display="flex"
                       gap="8px"

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -1010,17 +1010,19 @@ export const EmailTemplateManagement = () => {
                       {templateName}
                     </Text>
                   )}
-                  <Pencil
-                    size={20}
-                    cursor="pointer"
-                    onClick={() => {
-                      setRenameTarget({
-                        type: "template",
-                        item: { id: currentTemplateId, name: templateName },
-                      });
-                      setShowRenameDialog(true);
-                    }}
-                  />
+                  {isTemplateEditable && (
+                    <Pencil
+                      size={20}
+                      cursor="pointer"
+                      onClick={() => {
+                        setRenameTarget({
+                          type: "template",
+                          item: { id: currentTemplateId, name: templateName },
+                        });
+                        setShowRenameDialog(true);
+                      }}
+                    />
+                  )}
                 </HStack>
                 
                 <HStack spacing={4} ml="auto">
@@ -1054,7 +1056,24 @@ export const EmailTemplateManagement = () => {
                         await handleSaveButtonClick();
                         return;
                       }
+                      const isEnteringEditMode = !isEditingTemplate;
                       setIsEditingTemplate((prev) => !prev);
+                      // When entering edit mode, prompt to move/link orphaned templates
+                      if (isEnteringEditMode) {
+                        try {
+                          const templateIdToCheck =
+                            currentTemplateId ||
+                            (urlTemplateId && !urlTemplateId.startsWith("new-")
+                              ? urlTemplateId
+                              : null);
+                          const shouldOpenMoveModal = await hasNoLinkedFolders(templateIdToCheck);
+                          if (shouldOpenMoveModal) {
+                            openMoveTemplateModalWithDefaultFolder();
+                          }
+                        } catch (error) {
+                          // don't block user flow on lookup errors
+                        }
+                      }
                     }}
                   >
                     {hasUnsavedChanges ? <Save size={16} /> : <Pencil size={16} />}


### PR DESCRIPTION
## Description
Changed some spacing (folders view) and buttons (editing mode) to match hi-fi. It was decently aligned to begin with.

Changed it so that when you click edit, the buttons in the background grey out like they do in the figma. Everything else was similar to the hi-fi, and was stress tested. - Sindhuja

## Screenshots/Media
<img width="2202" height="1062" alt="image" src="https://github.com/user-attachments/assets/e3def9f7-4f5a-4218-8e8c-a5137e7c9c8d" />
<img width="2190" height="1055" alt="image" src="https://github.com/user-attachments/assets/814c4137-1675-47f6-8bca-78419535c524" />
<img width="1919" height="988" alt="Screenshot 2026-06-03 103746" src="https://github.com/user-attachments/assets/0d57fc95-7728-4b6f-9794-7066089b8fce" />


## Issues
Closes #159 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned folders view spacing to 30px and enforced a strict edit mode for templates per Linear #159. Titles, subjects, and rich text are read‑only by default with clear button states; folder actions disable while renaming to match hi‑fi.

- **New Features**
  - Edit mode: templates are read‑only until enabled; new and “new-*” templates open in edit; state resets after load/save; entering edit mode prompts to move/link orphaned templates.
  - Editor and inputs: pass `isEditable` to the rich text editor, toggle `setEditable`, hide the toolbar in read‑only, set correct cursors; subject input is readOnly with a white background.
  - Buttons: Edit toggles when there are no changes; Save appears only with unsaved changes; Delete is solid gray in edit mode without unsaved changes.

- **Bug Fixes**
  - Disable and gray out new/delete folder actions while the rename dialog is open.

<sup>Written for commit 181fa04fa102de6c444ac6049f4db946825b97a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/eldr/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



