### PR TITLE
158 Clinic Management Hifi Fixes

### DIFF
--- a/client/src/components/eventManagement/CreateEmailNotification.jsx
+++ b/client/src/components/eventManagement/CreateEmailNotification.jsx
@@ -259,11 +259,10 @@ export const CreateEmailNotification = () => {
     >
       <HStack
         fontSize="lg"
-        gap={1}
+        gap={5}
         flexWrap="wrap"
       >
         <Text
-          fontWeight="semibold"
           color="gray.700"
           cursor="pointer"
           onClick={() => navigate("/events")}
@@ -274,7 +273,6 @@ export const CreateEmailNotification = () => {
         <Text
           color="black"
           cursor="pointer"
-          fontWeight="semibold"
           onClick={() => navigate(`/events/${eventId}`)}
         >
           View Event
@@ -282,7 +280,6 @@ export const CreateEmailNotification = () => {
         <Text color="gray.400">›</Text>
         <Text
           color="blue.500"
-          fontWeight="semibold"
         >
           {isEditing ? "Edit Email Notification" : "Create Email Notification"}
         </Text>

--- a/client/src/components/eventManagement/CreateEmailNotification.jsx
+++ b/client/src/components/eventManagement/CreateEmailNotification.jsx
@@ -319,7 +319,7 @@ export const CreateEmailNotification = () => {
                 fontWeight="semibold"
                 color="gray.700"
               >
-                Timing
+                Time Before Event Start
               </Text>
               <Text
                 as="span"

--- a/client/src/components/eventManagement/CreatedEvent.jsx
+++ b/client/src/components/eventManagement/CreatedEvent.jsx
@@ -380,7 +380,7 @@ export const CreatedEvent = () => {
 
         {activeTab === "volunteers" && (
           <Box w="100%" bg="white" borderLeft="1px solid" borderRight="1px solid" borderBottom="1px solid" borderColor="gray.200" borderRadius="0 0 6px 6px" p={8}>
-            <EventVolunteerList eventId={eventId} />
+            <EventVolunteerList eventId={eventId} eventName={name}/>
           </Box>
         )}
 

--- a/client/src/components/eventManagement/CreatedEvent.jsx
+++ b/client/src/components/eventManagement/CreatedEvent.jsx
@@ -159,10 +159,9 @@ export const CreatedEvent = () => {
       {/* Breadcrumb */}
       <HStack
         fontSize="lg"
-        gap={1}
+        gap={5}
       >
         <Text
-          fontWeight="semibold"
           color="gray.800"
           cursor="pointer"
           onClick={() => navigate("/events")}

--- a/client/src/components/eventManagement/EmailNotificationTimeline.jsx
+++ b/client/src/components/eventManagement/EmailNotificationTimeline.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Box, Button, Flex, HStack, Table, Text } from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import {
   Calendar,
   CheckCircle2,
@@ -227,13 +227,30 @@ export const EmailNotificationTimeline = ({ eventId }) => {
                     {sendTiming}
                   </Table.Cell>
                   <Table.Cell verticalAlign="middle" py={4}>
-                    <Text
-                      fontSize="sm"
-                      color="gray.700"
-                      maxW="280px"
-                    >
-                      {templateLabel}
-                    </Text>
+                    {row.kind === "custom" && row.templateId ? (
+                      <Text
+                        as={Link}
+                        to={`/email/template/${row.templateId}`}
+                        fontSize="sm"
+                        color="blue.600"
+                        fontWeight="medium"
+                        maxW="280px"
+                        display="inline-flex"
+                        alignItems="center"
+                        gap={1.5}
+                        _hover={{ color: "blue.800", textDecoration: "underline" }}
+                      >
+                        {templateLabel} <span>&rarr;</span>
+                      </Text>
+                    ) : (
+                      <Text
+                        fontSize="sm"
+                        color="gray.700"
+                        maxW="280px"
+                      >
+                        {templateLabel}
+                      </Text>
+                    )}
                   </Table.Cell>
                   <Table.Cell verticalAlign="middle" py={4}>
                     <HStack justify="flex-start" gap={2} flexWrap="wrap">

--- a/client/src/components/eventManagement/EventManagement.jsx
+++ b/client/src/components/eventManagement/EventManagement.jsx
@@ -451,7 +451,7 @@ export const EventManagement = () => {
             </InputGroup>
 
             <Button
-              bg="#547b9b"
+              bg="#487C9E"
               color="white"
               borderRadius="4px"
               px={5}

--- a/client/src/components/eventManagement/EventVolunteerList.jsx
+++ b/client/src/components/eventManagement/EventVolunteerList.jsx
@@ -44,7 +44,7 @@ const buildVisiblePageNumbers = (totalPages, currentPage) => {
   });
 };
 
-export const EventVolunteerList = ({ eventId }) => {
+export const EventVolunteerList = ({ eventId, eventName }) => {
   const { backend } = useBackendContext();
   const [registrations, setRegistrations] = useState([]);
   const [registrationsLoading, setRegistrationsLoading] = useState(false);
@@ -139,7 +139,14 @@ export const EventVolunteerList = ({ eventId }) => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `volunteers-event-${eventId}.csv`;
+
+    const safeEventName = (eventName || "event")
+      .replace(/[<>:"/\\|?*]/g, "")
+      .trim()
+      .replace(/\s+/g, "-");
+      
+    a.download = `${safeEventName}-event-volunteer-list.csv`;
+
     a.click();
     URL.revokeObjectURL(url);
   };

--- a/client/src/components/eventManagement/EventVolunteerList.jsx
+++ b/client/src/components/eventManagement/EventVolunteerList.jsx
@@ -306,7 +306,13 @@ export const EventVolunteerList = ({ eventId }) => {
                       variant="ghost"
                       size="sm"
                       color="red.600"
+                      borderColor="#FECACA"
                       onClick={() => setDeleteTarget(row.id)}
+                      _hover={{
+                        borderColor: "red.600",
+                        bg: "red.600",
+                        color:"white",
+                      }}
                     >
                       <LuTrash2 />
                       Delete

--- a/client/src/components/eventManagement/createEvent.jsx
+++ b/client/src/components/eventManagement/createEvent.jsx
@@ -402,10 +402,9 @@ export const CreateEvent = () => {
       {/* Breadcrumb */}
       <HStack
         fontSize="lg"
-        gap={1}
+        gap={5}
       >
         <Text
-          fontWeight="semibold"
           color="gray.800"
           cursor="pointer"
           onClick={() => navigate("/events")}

--- a/client/src/components/eventManagement/createEvent.jsx
+++ b/client/src/components/eventManagement/createEvent.jsx
@@ -9,7 +9,6 @@ import {
   Flex,
   HStack,
   Input,
-  NativeSelect,
   Portal,
   Textarea,
   Text,
@@ -18,10 +17,9 @@ import {
 } from "@chakra-ui/react";
 
 import { useBackendContext } from "@/contexts/hooks/useBackendContext";
-import { LuMail, LuImageUp, LuTriangleAlert } from "react-icons/lu";
+import { LuMail, LuImageUp, LuTriangleAlert, LuChevronDown } from "react-icons/lu";
 import { useNavigate, useParams } from "react-router-dom";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { MdOutlineMailOutline } from "react-icons/md";
 import { EmailNotificationTimeline } from "./EmailNotificationTimeline";
 
 const parseTimeField = (ts) => {
@@ -64,6 +62,62 @@ const buildEditBaseline = (c, langNames) => {
     description: c.description ?? "",
     languagesKey: [...langNames].sort().join("|"),
   };
+};
+
+// Reusable styled dropdown matching the language combobox arrow style
+const StyledSelect = ({ value, onChange, options, placeholder, width = "100%", color }) => {
+  return (
+    <Box
+      position="relative"
+      w={width}
+      style={{ display: "inline-block" }}
+    >
+      <Box
+        as="select"
+        value={value}
+        onChange={onChange}
+        style={{
+          width: "100%",
+          border: "1px solid #CBD5E0",
+          borderRadius: "6px",
+          background: "white",
+          fontSize: "14px",
+          height: "44px",
+          paddingLeft: "12px",
+          paddingRight: "32px",
+          color: color || (value ? "black" : "#718096"),
+          appearance: "none",
+          WebkitAppearance: "none",
+          MozAppearance: "none",
+          cursor: "pointer",
+          outline: "none",
+        }}
+      >
+        {placeholder && (
+          <option value="" disabled hidden>
+            {placeholder}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </Box>
+      <Box
+        position="absolute"
+        right="8px"
+        top="50%"
+        transform="translateY(-50%)"
+        pointerEvents="none"
+        color="gray.500"
+        display="flex"
+        alignItems="center"
+      >
+        <LuChevronDown size={16} />
+      </Box>
+    </Box>
+  );
 };
 
 export const CreateEvent = () => {
@@ -175,7 +229,6 @@ export const CreateEvent = () => {
     fetchSource();
   }, [isDuplicating, sourceId, backend]);
 
-  // raf edit start
   const languagesKey = useMemo(
     () => [...languages].sort().join("|"),
     [languages]
@@ -248,7 +301,6 @@ export const CreateEvent = () => {
     navigate(`/events/${eventId}`, { state: { editFeedback: "discarded" } });
   };
 
-  // raf edit end
   const filteredLanguages = useMemo(
     () =>
       allLanguages
@@ -277,16 +329,6 @@ export const CreateEvent = () => {
     color: "gray.500",
     _placeholder: { color: "gray.400" },
     _focus: { borderColor: "blue.400", boxShadow: "none" },
-  };
-
-  const selectStyle = {
-    border: "1px solid #CBD5E0",
-    borderRadius: "6px",
-    background: "white",
-    fontSize: "14px",
-    height: "44px",
-    paddingLeft: "12px",
-    color: "#718096",
   };
 
   const formatTime = (value) => {
@@ -344,7 +386,6 @@ export const CreateEvent = () => {
         );
       }
 
-      // TODO: add proficiency field to form
       await Promise.all(
         languages.map(async (langName) => {
           const lang = allLanguages.find((l) => l.language === langName);
@@ -368,25 +409,58 @@ export const CreateEvent = () => {
   };
 
   const Label = ({ children }) => (
-    <HStack
-      gap={0}
-      mb={1}
-    >
-      <Text
-        fontSize="sm"
-        fontWeight="semibold"
-        color="gray.700"
-      >
+    <HStack gap={0} mb={1}>
+      <Text fontSize="sm" fontWeight="semibold" color="gray.700">
         {children}
       </Text>
-      <Text
-        color="red.500"
-        ml="2px"
-      >
-        *
-      </Text>
+      <Text color="red.500" ml="2px">*</Text>
     </HStack>
   );
+
+  const US_STATES = [
+    { value: "AL", label: "AL" }, { value: "AK", label: "AK" },
+    { value: "AZ", label: "AZ" }, { value: "AR", label: "AR" },
+    { value: "CA", label: "CA" }, { value: "CO", label: "CO" },
+    { value: "CT", label: "CT" }, { value: "DE", label: "DE" },
+    { value: "FL", label: "FL" }, { value: "GA", label: "GA" },
+    { value: "HI", label: "HI" }, { value: "ID", label: "ID" },
+    { value: "IL", label: "IL" }, { value: "IN", label: "IN" },
+    { value: "IA", label: "IA" }, { value: "KS", label: "KS" },
+    { value: "KY", label: "KY" }, { value: "LA", label: "LA" },
+    { value: "ME", label: "ME" }, { value: "MD", label: "MD" },
+    { value: "MA", label: "MA" }, { value: "MI", label: "MI" },
+    { value: "MN", label: "MN" }, { value: "MS", label: "MS" },
+    { value: "MO", label: "MO" }, { value: "MT", label: "MT" },
+    { value: "NE", label: "NE" }, { value: "NV", label: "NV" },
+    { value: "NH", label: "NH" }, { value: "NJ", label: "NJ" },
+    { value: "NM", label: "NM" }, { value: "NY", label: "NY" },
+    { value: "NC", label: "NC" }, { value: "ND", label: "ND" },
+    { value: "OH", label: "OH" }, { value: "OK", label: "OK" },
+    { value: "OR", label: "OR" }, { value: "PA", label: "PA" },
+    { value: "RI", label: "RI" }, { value: "SC", label: "SC" },
+    { value: "SD", label: "SD" }, { value: "TN", label: "TN" },
+    { value: "TX", label: "TX" }, { value: "UT", label: "UT" },
+    { value: "VT", label: "VT" }, { value: "VA", label: "VA" },
+    { value: "WA", label: "WA" }, { value: "WV", label: "WV" },
+    { value: "WI", label: "WI" }, { value: "WY", label: "WY" },
+  ];
+
+  const PERIOD_OPTIONS = [
+    { value: "AM", label: "AM" },
+    { value: "PM", label: "PM" },
+  ];
+
+  const CLINIC_TYPE_OPTIONS = [
+    { value: "Estate Planning", label: "Estate Planning" },
+    { value: "Limited Conservatorship", label: "Limited Conservatorship" },
+    { value: "Probate Note Clearing", label: "Probate Note Clearing" },
+  ];
+
+  const EVENT_FORMAT_OPTIONS = [
+    { value: "in-person", label: "In-Person" },
+    { value: "hybrid", label: "Hybrid" },
+    { value: "online", label: "Online" },
+  ];
 
   return (
     <VStack
@@ -400,47 +474,25 @@ export const CreateEvent = () => {
       gap={6}
     >
       {/* Breadcrumb */}
-      <HStack
-        fontSize="lg"
-        gap={5}
-      >
-        <Text
-          color="gray.800"
-          cursor="pointer"
-          onClick={() => navigate("/events")}
-        >
+      <HStack fontSize="lg" gap={5}>
+        <Text color="gray.800" cursor="pointer" onClick={() => navigate("/events")}>
           Event Catalog
         </Text>
         <Text color="gray.400">›</Text>
         {isEditing ? (
-          <Text color="blue.600">
-            Edit Event
-          </Text>
+          <Text color="blue.600">Edit Event</Text>
         ) : isDuplicating ? (
-          <Text
-            color="blue.500"
-            cursor="pointer"
-            onClick={() => navigate("/events")}
-          >
+          <Text color="blue.500" cursor="pointer" onClick={() => navigate("/events")}>
             Duplicate Event
           </Text>
         ) : (
-          <Text color="blue.600">
-            Create New Event
-          </Text>
+          <Text color="blue.600">Create New Event</Text>
         )}
       </HStack>
 
       {/* Title */}
-      <HStack
-        align="center"
-        gap={3}
-      >
-        <Text
-          fontSize="4xl"
-          fontWeight="bold"
-          color="#1A202C"
-        >
+      <HStack align="center" gap={3}>
+        <Text fontSize="4xl" fontWeight="bold" color="#1A202C">
           {isEditing ? "Edit Event" : isDuplicating ? "Duplicate Event" : "Create New Event"}
         </Text>
         {isEditing && (
@@ -462,12 +514,7 @@ export const CreateEvent = () => {
       </HStack>
 
       {/* Tabs */}
-      <HStack
-        gap={1}
-        borderBottom="1px solid #E2E8F0"
-        w="100%"
-        align="end"
-      >
+      <HStack gap={1} borderBottom="1px solid #E2E8F0" w="100%" align="end">
         {tabs.map((tab) => (
           <Button
             key={tab.key}
@@ -495,12 +542,7 @@ export const CreateEvent = () => {
 
       {/* Form card */}
       {activeTab === "details" && (
-        <VStack
-          w="100%"
-          align="start"
-          gap={8}
-          pt={{ base: 2, md: 4 }}
-        >
+        <VStack w="100%" align="start" gap={8} pt={{ base: 2, md: 4 }}>
           {/* Row 1: Clinic Type + Event Name */}
           <Flex
             w="100%"
@@ -508,37 +550,17 @@ export const CreateEvent = () => {
             direction={{ base: "column", lg: "row" }}
             align={{ base: "stretch", lg: "end" }}
           >
-            <VStack
-              align="start"
-              gap={1}
-              w={{ base: "100%", lg: "30%" }}
-              flexShrink={0}
-            >
+            <VStack align="start" gap={1} w={{ base: "100%", lg: "30%" }} flexShrink={0}>
               <Label>Clinic Type</Label>
-              <NativeSelect.Root w="100%">
-                <NativeSelect.Field
-                  placeholder="Select"
-                  value={type}
-                  onChange={(e) => setType(e.target.value)}
-                  style={selectStyle}
-                >
-                  <option value="Estate Planning">Estate Planning</option>
-                  <option value="Limited Conservatorship">
-                    Limited Conservatorship
-                  </option>
-                  <option value="Probate Note Clearing">
-                    Probate Note Clearing
-                  </option>
-                </NativeSelect.Field>
-              </NativeSelect.Root>
+              <StyledSelect
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+                options={CLINIC_TYPE_OPTIONS}
+                placeholder="Select"
+              />
             </VStack>
 
-            <VStack
-              align="start" // incoming was align="end"
-              gap={1} // incoming was gap={8}
-              flex={1}
-              w="100%"
-            >
+            <VStack align="start" gap={1} flex={1} w="100%">
               <Label>Event Name</Label>
               <Input
                 placeholder="Type here"
@@ -557,41 +579,20 @@ export const CreateEvent = () => {
             direction={{ base: "column", lg: "row" }}
             align={{ base: "stretch", lg: "end" }}
           >
-            <VStack
-              align="start"
-              gap={1}
-              flexShrink={0}
-              w={{ base: "100%", lg: "15%" }}
-            >
+            <VStack align="start" gap={1} flexShrink={0} w={{ base: "100%", lg: "15%" }}>
               <Label>Event Format</Label>
-              <NativeSelect.Root w={{ base: "100%", lg: "full" }}>
-                <NativeSelect.Field
-                  value={locationType}
-                  onChange={(e) => setLocationType(e.target.value)}
-                  style={{ ...selectStyle, color: "black" }}
-                >
-                  <option value="in-person">In-Person</option>
-                  <option value="hybrid">Hybrid</option>
-                  <option value="online">Online</option>
-                </NativeSelect.Field>
-              </NativeSelect.Root>
+              <StyledSelect
+                value={locationType}
+                onChange={(e) => setLocationType(e.target.value)}
+                options={EVENT_FORMAT_OPTIONS}
+                color="black"
+              />
             </VStack>
 
-            <VStack
-              align="start"
-              gap={1}
-              flex={1}
-              w="100%"
-            >
+            <VStack align="start" gap={1} flex={1} w="100%">
               <Label>Location</Label>
-              <HStack
-                w="100%"
-                gap={2}
-                flexWrap="wrap"
-                align="start"
-              >
-                {(locationType === "in-person" ||
-                  locationType === "hybrid") && (
+              <HStack w="100%" gap={2} flexWrap="wrap" align="start">
+                {(locationType === "in-person" || locationType === "hybrid") && (
                   <>
                     <Input
                       placeholder="Address"
@@ -606,16 +607,17 @@ export const CreateEvent = () => {
                       value={city}
                       onChange={(e) => setCity(e.target.value)}
                       {...fieldStyle}
-                      w={{ base: "calc(50% - 4px)", md: "20%"}}
+                      w={{ base: "calc(50% - 4px)", md: "20%" }}
                     />
-                    <Input
-                      placeholder="State"
-                      value={state}
-                      onChange={(e) => setState(e.target.value)}
-                      {...fieldStyle}
-                      w={{ base: "calc(25% - 6px)", md: "95px" }}
-                      maxLength={2}
-                    />
+                    <Box w={{ base: "calc(25% - 6px)", md: "95px" }}>
+                      <StyledSelect
+                        value={state}
+                        onChange={(e) => setState(e.target.value)}
+                        options={US_STATES}
+                        placeholder="State"
+                        color={state ? "black" : undefined}
+                      />
+                    </Box>
                     <Input
                       placeholder="Zip Code"
                       value={zip}
@@ -647,12 +649,7 @@ export const CreateEvent = () => {
             align={{ base: "stretch", lg: "end" }}
             flexWrap="wrap"
           >
-            <VStack
-              align="start"
-              gap={1}
-              w={{ base: "100%", lg: "25%" }}
-              flexShrink={0}
-            >
+            <VStack align="start" gap={1} w={{ base: "100%", lg: "25%" }} flexShrink={0}>
               <Label>Date</Label>
               <Input
                 type="date"
@@ -663,17 +660,9 @@ export const CreateEvent = () => {
               />
             </VStack>
 
-            <VStack
-              align="start"
-              gap={1}
-              flex={1}
-              w="100%"
-            >
+            <VStack align="start" gap={1} flex={1} w="100%">
               <Label>Event Time</Label>
-              <HStack
-                gap={2}
-                flexWrap="wrap"
-              >
+              <HStack gap={2} flexWrap="wrap">
                 <Input
                   placeholder="9:00"
                   value={startTime}
@@ -682,20 +671,14 @@ export const CreateEvent = () => {
                   w="70px"
                   textAlign="center"
                 />
-                <NativeSelect.Root w="70px">
-                  <NativeSelect.Field
+                <Box w="75px">
+                  <StyledSelect
                     value={startPeriod}
                     onChange={(e) => setStartPeriod(e.target.value)}
-                    style={{
-                      ...selectStyle,
-                      paddingLeft: "8px",
-                      color: "black",
-                    }}
-                  >
-                    <option value="AM">AM</option>
-                    <option value="PM">PM</option>
-                  </NativeSelect.Field>
-                </NativeSelect.Root>
+                    options={PERIOD_OPTIONS}
+                    color="black"
+                  />
+                </Box>
                 <Text color="gray.400">-</Text>
                 <Input
                   placeholder="12:00"
@@ -705,29 +688,18 @@ export const CreateEvent = () => {
                   w="70px"
                   textAlign="center"
                 />
-                <NativeSelect.Root w="70px">
-                  <NativeSelect.Field
+                <Box w="75px">
+                  <StyledSelect
                     value={endPeriod}
                     onChange={(e) => setEndPeriod(e.target.value)}
-                    style={{
-                      ...selectStyle,
-                      paddingLeft: "8px",
-                      color: "black",
-                    }}
-                  >
-                    <option value="AM">AM</option>
-                    <option value="PM">PM</option>
-                  </NativeSelect.Field>
-                </NativeSelect.Root>
+                    options={PERIOD_OPTIONS}
+                    color="black"
+                  />
+                </Box>
               </HStack>
             </VStack>
 
-            <VStack
-              align="start"
-              gap={1}
-              w={{ base: "100%", lg: "15%" }}
-              flexShrink={0}
-            >
+            <VStack align="start" gap={1} w={{ base: "100%", lg: "15%" }} flexShrink={0}>
               <Label>Target Number</Label>
               <Input
                 placeholder="Type number"
@@ -739,12 +711,7 @@ export const CreateEvent = () => {
               />
             </VStack>
 
-            <VStack
-              align="start"
-              gap={1}
-              w={{ base: "100%", lg: "15%" }}
-              flexShrink={0}
-            >
+            <VStack align="start" gap={1} w={{ base: "100%", lg: "15%" }} flexShrink={0}>
               <Label>Maximum</Label>
               <Input
                 placeholder="Type number"
@@ -758,11 +725,7 @@ export const CreateEvent = () => {
           </Flex>
 
           {/* Row 4: Languages */}
-          <VStack
-            align="start"
-            gap={1}
-            w="100%"
-          >
+          <VStack align="start" gap={1} w="100%">
             <Label>Languages</Label>
             <Combobox.Root
               multiple
@@ -771,13 +734,14 @@ export const CreateEvent = () => {
               value={languages}
               collection={languageCollection}
               onValueChange={(details) => setLanguages(details.value)}
-              onInputValueChange={(details) =>
-                setLanguageSearch(details.inputValue)
-              }
+              onInputValueChange={(details) => setLanguageSearch(details.inputValue)}
             >
               <Combobox.Control
                 style={{
-                  ...selectStyle,
+                  border: "1px solid #CBD5E0",
+                  borderRadius: "6px",
+                  background: "white",
+                  fontSize: "14px",
                   height: "auto",
                   minHeight: "44px",
                   display: "flex",
@@ -785,11 +749,7 @@ export const CreateEvent = () => {
                   paddingRight: "8px",
                 }}
               >
-                <Wrap
-                  gap="1"
-                  flex={1}
-                  py={1}
-                >
+                <Wrap gap="1" flex={1} py={1}>
                   {languages.map((lang) => (
                     <Badge
                       key={lang}
@@ -815,9 +775,7 @@ export const CreateEvent = () => {
                     </Badge>
                   ))}
                   <Combobox.Input
-                    placeholder={
-                      languages.length === 0 ? "Select languages" : ""
-                    }
+                    placeholder={languages.length === 0 ? "Select languages" : ""}
                     onKeyDown={(e) => {
                       if (
                         (e.key === "Backspace" || e.key === "Delete") &&
@@ -832,7 +790,7 @@ export const CreateEvent = () => {
                       outline: "none",
                       background: "transparent",
                       fontSize: "14px",
-                      color: "#718096",
+                      color: "#A0AEC0",
                       minWidth: "80px",
                       flex: 1,
                     }}
@@ -846,14 +804,9 @@ export const CreateEvent = () => {
                 <Combobox.Positioner>
                   <Combobox.Content>
                     <Combobox.ItemGroup>
-                      <Combobox.ItemGroupLabel>
-                        Languages
-                      </Combobox.ItemGroupLabel>
+                      <Combobox.ItemGroupLabel>Languages</Combobox.ItemGroupLabel>
                       {filteredLanguages.map((lang) => (
-                        <Combobox.Item
-                          key={lang}
-                          item={lang}
-                        >
+                        <Combobox.Item key={lang} item={lang}>
                           {lang}
                           <Combobox.ItemIndicator />
                         </Combobox.Item>
@@ -867,17 +820,8 @@ export const CreateEvent = () => {
           </VStack>
 
           {/* Row 5: Description */}
-          <VStack
-            align="start"
-            gap={1}
-            w="100%"
-          >
-            <HStack
-              w="100%"
-              justify="space-between"
-              align="center"
-              mb={1}
-            >
+          <VStack align="start" gap={1} w="100%">
+            <HStack w="100%" justify="space-between" align="center" mb={1}>
               <Label>Description</Label>
               <Button
                 variant="outline"
@@ -913,25 +857,12 @@ export const CreateEvent = () => {
       )}
 
       {activeTab !== "details" && (
-        <Flex
-          w="100%"
-          p={8}
-          bg="white"
-          border="1px solid #E2E8F0"
-          borderRadius="4px"
-        >
+        <Flex w="100%" p={8} bg="white" border="1px solid #E2E8F0" borderRadius="4px">
           {activeTab === "email" ? (
             <EmailNotificationTimeline eventId={isEditing ? eventId : undefined} />
           ) : (
-            <Flex
-              align="center"
-              justify="center"
-              minH="200px"
-            >
-              <Text
-                color="gray.400"
-                fontSize="sm"
-              >
+            <Flex align="center" justify="center" minH="200px">
+              <Text color="gray.400" fontSize="sm">
                 {tabs.find((t) => t.key === activeTab)?.label}
               </Text>
             </Flex>
@@ -940,12 +871,7 @@ export const CreateEvent = () => {
       )}
 
       {/* Action buttons */}
-      <HStack
-        w="100%"
-        justify="flex-end"
-        gap={3}
-        pt={0} // was pt={2} on incoming
-      >
+      <HStack w="100%" justify="flex-end" gap={3} pt={0}>
         <Button
           bg="#4A7FA5"
           color="white"
@@ -964,7 +890,7 @@ export const CreateEvent = () => {
           fontSize="sm"
           border="1px solid #CBD5E0"
           color="gray.600"
-          onClick={handleCancelClick} // incoming was onClick={() => navigate(isEditing ? `/events/${eventId}` : "/events")}
+          onClick={handleCancelClick}
         >
           Cancel
         </Button>

--- a/client/src/components/eventManagement/createEvent.jsx
+++ b/client/src/components/eventManagement/createEvent.jsx
@@ -823,19 +823,6 @@ export const CreateEvent = () => {
           <VStack align="start" gap={1} w="100%">
             <HStack w="100%" justify="space-between" align="center" mb={1}>
               <Label>Description</Label>
-              <Button
-                variant="outline"
-                border="1px solid #E2E8F0"
-                bg="white"
-                color="gray.600"
-                borderRadius="4px"
-                size="sm"
-                px={3}
-                _hover={{ bg: "gray.50" }}
-              >
-                <LuImageUp />
-                Upload images
-              </Button>
             </HStack>
             <Textarea
               value={description}


### PR DESCRIPTION
## Description

Worked with Nandita, Kylie, and Julianna to review the Clinic Management flow against the hi-fi Figma designs.

### Main Updates
- Increased spacing and removed bold styling from breadcrumb items and labels.
- Added dropdown indicators to **Event Time**, **Clinic Type**, **Event Format**, and **State** fields in "Edit Event" view.
- Standardized placeholder text colors across all form inputs.
- Updated email notification description for user clarity.
- Added navigation from selected email templates back to their corresponding template details.
- Updated delete button styling to match Figma with a red outlined default state and solid red hover state.
- Include event titles in downloaded volunteer lists instead of generated event IDs (e.g. `event-77`).

## Screenshots/Media

### Edit Event View
<img width="1461" height="781" alt="Screenshot 2026-06-01 at 10 17 17 AM" src="https://github.com/user-attachments/assets/f4c1753f-cf4b-4e34-bffd-0c3e693c13d4" />

### Email Template Links
#### Links to Corresponding Email Template (if exists)
<img width="1355" height="616" alt="Screenshot 2026-06-01 at 10 18 01 AM" src="https://github.com/user-attachments/assets/fce932ab-0f79-4ed8-b015-c1647710802a" />

## Issues
Closes #158

## Additional Notes
- Removed non-implemented image upload functionality for events.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Clinic Management flow to match the hi‑fi Figma for clarity and consistency. Adds template linking, improves dropdowns and labels, and fixes CSV export naming. Addresses issue #158.

- **New Features**
  - Link from email notification timeline to the selected custom template when a template exists.
  - Volunteer CSV download now uses the event title in a safe filename (e.g., event-name-event-volunteer-list.csv).

- **Bug Fixes**
  - Breadcrumbs: increased spacing and removed bold weights to match Figma.
  - Edit/Create Event: added dropdown indicators for Clinic Type, Event Format, State, and AM/PM; standardized placeholder text color.
  - Email notifications: renamed "Timing" to "Time Before Event Start" for clarity.
  - Delete buttons match Figma (red outline, solid red on hover); removed non-functioning "Upload images" button.

<sup>Written for commit 00711e06f86a458ddb71c386b86acc78ddd7465c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/eldr/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

