### PR TITLE
Small mitigation to avoid db from getting overused

### DIFF
--- a/server/routes/scheduler.js
+++ b/server/routes/scheduler.js
@@ -1,9 +1,9 @@
 import { db } from "@/db/db-pgp";
 import cron from "node-cron";
 
+import { renderClinicEmailTemplate } from "../common/clinicEmailTemplate.js";
 import { sendEmail } from "./emailService.js";
 import { parseAndStripScheduledEmailEventMarker } from "./scheduledEmailEventMarker.js";
-import { renderClinicEmailTemplate } from "../common/clinicEmailTemplate.js";
 
 async function distinctRegistrantEmails(clinicId) {
   const rows = await db.query(
@@ -52,7 +52,7 @@ async function getClinicEmailContext(clinicId) {
  * Deletes each row before sending.
  * Optional `<!--eldr-event:ID-->` prefix in body fans the same HTML out to registered volunteers.
  */
-cron.schedule("* * * * *", async () => {
+cron.schedule("0 * * * *", async () => {
   try {
     // Process one row per iteration to avoid long locks; loop until none due.
     // eslint-disable-next-line no-constant-condition
@@ -76,16 +76,26 @@ cron.schedule("* * * * *", async () => {
       const parsed = parseAndStripScheduledEmailEventMarker(email.body);
       const clinicId = email.clinic_id ?? parsed.clinicId;
       const bodyHtml = parsed.html;
-      const clinic = clinicId != null ? await getClinicEmailContext(clinicId) : null;
-      const registrants = clinicId != null ? await distinctRegistrantEmails(clinicId) : [];
+      const clinic =
+        clinicId != null ? await getClinicEmailContext(clinicId) : null;
+      const registrants =
+        clinicId != null ? await distinctRegistrantEmails(clinicId) : [];
       const primaryRegistrant = registrants.find(
-        (r) => r.email.toLowerCase() === String(email.to_email ?? "").trim().toLowerCase()
+        (r) =>
+          r.email.toLowerCase() ===
+          String(email.to_email ?? "")
+            .trim()
+            .toLowerCase()
       );
       const renderedSubject = clinic
-        ? renderClinicEmailTemplate(email.subject, clinic, { name: primaryRegistrant?.name })
+        ? renderClinicEmailTemplate(email.subject, clinic, {
+            name: primaryRegistrant?.name,
+          })
         : email.subject;
       const renderedBody = clinic
-        ? renderClinicEmailTemplate(bodyHtml, clinic, { name: primaryRegistrant?.name })
+        ? renderClinicEmailTemplate(bodyHtml, clinic, {
+            name: primaryRegistrant?.name,
+          })
         : bodyHtml;
 
       try {
@@ -104,10 +114,14 @@ cron.schedule("* * * * *", async () => {
           let ok = 0;
           for (const recipient of registrants) {
             const perRecipientSubject = clinic
-              ? renderClinicEmailTemplate(email.subject, clinic, { name: recipient.name })
+              ? renderClinicEmailTemplate(email.subject, clinic, {
+                  name: recipient.name,
+                })
               : email.subject;
             const perRecipientBody = clinic
-              ? renderClinicEmailTemplate(bodyHtml, clinic, { name: recipient.name })
+              ? renderClinicEmailTemplate(bodyHtml, clinic, {
+                  name: recipient.name,
+                })
               : bodyHtml;
             try {
               await sendEmail({
@@ -128,12 +142,21 @@ cron.schedule("* * * * *", async () => {
           );
         }
       } catch (sendError) {
-        console.error(`❌ Failed to send scheduled email ID: ${email.id}`, sendError);
+        console.error(
+          `❌ Failed to send scheduled email ID: ${email.id}`,
+          sendError
+        );
         try {
           await db.query(
             `INSERT INTO scheduled_emails (clinic_id, to_email, subject, body, send_at)
              VALUES ($1, $2, $3, $4, $5)`,
-            [email.clinic_id ?? null, email.to_email, email.subject, email.body, email.send_at]
+            [
+              email.clinic_id ?? null,
+              email.to_email,
+              email.subject,
+              email.body,
+              email.send_at,
+            ]
           );
           console.log(`↩ Re-queued failed email (was ID ${email.id})`);
         } catch (requeueErr) {


### PR DESCRIPTION
## Description
cron job reduced to hourly checks for scheduled emails
## Screenshots/Media

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the scheduled email job to run hourly (0 * * * *) instead of every minute to reduce database load. Sending logic remains the same, including rendering and fan-out to registrants.

<sup>Written for commit b8cb6f228708e5b99e27dfe7159a8631f44bda2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/eldr/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

