### PR TITLE
feat(email-templates): add variable autocomplete popover and edit-mode cancel flow

### DIFF
--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -240,6 +240,21 @@ export const NewTemplateSection = ({
     setEditorPopover((prev) => ({ ...prev, isOpen: false }));
   }, []);
 
+  const updateEditorPopoverPosition = useCallback((editorInstance) => {
+    if (!editorInstance || !editorBoxRef.current) return;
+    const { state, view } = editorInstance;
+    const { selection } = state;
+    const { from, empty } = selection;
+
+    if (!empty) return;
+
+    const coords = view.coordsAtPos(from);
+    const top = coords.bottom + 4;
+    const left = Math.max(8, Math.min(coords.left, window.innerWidth - 330));
+
+    setEditorPopover((prev) => (prev.isOpen ? { ...prev, position: { top, left } } : prev));
+  }, []);
+
   const selectEditorOption = useCallback((option, viewInstance) => {
     if (!viewInstance || !option) return;
 
@@ -403,7 +418,7 @@ export const NewTemplateSection = ({
         setSubjectPopover((prev) => ({ ...prev, position: { top, left } }));
       }
       if (editorPopover.isOpen && editor?.view) {
-        checkEditorAutocomplete(editor);
+        updateEditorPopoverPosition(editor);
       }
     };
 
@@ -413,7 +428,7 @@ export const NewTemplateSection = ({
       window.removeEventListener("scroll", handleScrollOrResize, true);
       window.removeEventListener("resize", handleScrollOrResize);
     };
-  }, [subjectPopover.isOpen, editorPopover.isOpen, checkEditorAutocomplete, editor]);
+  }, [subjectPopover.isOpen, editorPopover.isOpen, updateEditorPopoverPosition, editor]);
 
   useEffect(() => {
     if (!editor) return;

--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -1,5 +1,5 @@
 import { Box, Input, Text, VStack } from "@chakra-ui/react";
-import { useEffect } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 
 import { Control, RichTextEditor } from "@/components/ui/rich-text-editor";
 import Subscript from "@tiptap/extension-subscript";
@@ -8,6 +8,9 @@ import TextAlign from "@tiptap/extension-text-align";
 import { TextStyleKit } from "@tiptap/extension-text-style";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import { TextSelection } from "@tiptap/pm/state";
+
+import { VariableAutocompletePopover, AVAILABLE_VARIABLES } from "./VariableAutocompletePopover";
 
 export const NewTemplateSection = ({
   templateSubject,
@@ -16,6 +19,237 @@ export const NewTemplateSection = ({
   setTemplateContent,
   isEditable = true,
 }) => {
+  // Helper to filter options
+  const getFilteredOptions = (query) =>
+    AVAILABLE_VARIABLES.filter((item) =>
+      item.label.toLowerCase().includes((query || "").trim().toLowerCase())
+    );
+
+  // ----------------------------------------------------
+  // Subject Input State & Logic
+  // ----------------------------------------------------
+  const subjectInputRef = useRef(null);
+  const subjectContainerRef = useRef(null);
+  const [subjectPopover, setSubjectPopover] = useState({
+    isOpen: false,
+    query: "",
+    selectedIndex: 0,
+    position: { top: 0, left: 0 },
+  });
+
+  const checkSubjectAutocomplete = useCallback((val, cursorPos) => {
+    const textBefore = val.slice(0, cursorPos);
+    const lastOpenIndex = textBefore.lastIndexOf("{{");
+
+    if (lastOpenIndex !== -1) {
+      const textBetween = textBefore.slice(lastOpenIndex + 2);
+      if (!textBetween.includes("}") && !textBetween.includes("\n")) {
+        setSubjectPopover((prev) => ({
+          ...prev,
+          isOpen: true,
+          query: textBetween,
+          selectedIndex: 0,
+          position: { top: 44, left: 0 }, // Position right beneath input box
+        }));
+        return;
+      }
+    }
+    setSubjectPopover((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const selectSubjectOption = useCallback((option) => {
+    const input = subjectInputRef.current;
+    if (!input || !option) return;
+
+    const { selectionStart, value } = input;
+    const textBefore = value.slice(0, selectionStart);
+    const lastOpenIndex = textBefore.lastIndexOf("{{");
+    if (lastOpenIndex === -1) return;
+
+    let afterIndex = selectionStart;
+    if (value.slice(selectionStart, selectionStart + 2) === "}}") {
+      afterIndex = selectionStart + 2;
+    }
+
+    const before = value.slice(0, lastOpenIndex);
+    const after = value.slice(afterIndex);
+    const replacement = `{{${option.label}}}`;
+    const newValue = before + replacement + after;
+
+    setTemplateSubject(newValue);
+
+    const newCursor = (before + replacement).length;
+    setTimeout(() => {
+      if (subjectInputRef.current) {
+        subjectInputRef.current.focus();
+        subjectInputRef.current.setSelectionRange(newCursor, newCursor);
+      }
+    }, 0);
+
+    setSubjectPopover({ isOpen: false, query: "", selectedIndex: 0, position: { top: 0, left: 0 } });
+  }, [setTemplateSubject]);
+
+  const handleSubjectKeyDown = (e) => {
+    if (!isEditable) return;
+    const input = subjectInputRef.current;
+    if (!input) return;
+
+    const { selectionStart, selectionEnd, value } = input;
+
+    // Auto-close double curly braces: typing '{' after another '{' -> inserts '}}' and puts cursor inside '{{|}}'
+    if (e.key === "{" && selectionStart === selectionEnd) {
+      const charBefore = value.slice(selectionStart - 1, selectionStart);
+      if (charBefore === "{") {
+        e.preventDefault();
+        const before = value.slice(0, selectionStart);
+        const after = value.slice(selectionEnd);
+        const nextValue = before + "{}}" + after;
+        setTemplateSubject(nextValue);
+
+        const newCursorPos = selectionStart + 1;
+        setTimeout(() => {
+          if (subjectInputRef.current) {
+            subjectInputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+            checkSubjectAutocomplete(nextValue, newCursorPos);
+          }
+        }, 0);
+        return;
+      }
+    }
+
+    // Autocomplete popup navigation & selection
+    if (subjectPopover.isOpen) {
+      const filtered = getFilteredOptions(subjectPopover.query);
+      if (filtered.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSubjectPopover((prev) => ({
+            ...prev,
+            selectedIndex: (prev.selectedIndex + 1) % filtered.length,
+          }));
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSubjectPopover((prev) => ({
+            ...prev,
+            selectedIndex: (prev.selectedIndex - 1 + filtered.length) % filtered.length,
+          }));
+          return;
+        }
+        if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          selectSubjectOption(filtered[subjectPopover.selectedIndex]);
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setSubjectPopover((prev) => ({ ...prev, isOpen: false }));
+          return;
+        }
+      }
+    }
+  };
+
+  const handleSubjectChange = (e) => {
+    const val = e.target.value;
+    setTemplateSubject(val);
+    const cursorPos = e.target.selectionStart;
+    checkSubjectAutocomplete(val, cursorPos);
+  };
+
+  const handleSubjectClick = () => {
+    if (subjectInputRef.current) {
+      checkSubjectAutocomplete(subjectInputRef.current.value, subjectInputRef.current.selectionStart);
+    }
+  };
+
+  // ----------------------------------------------------
+  // Rich Text Editor (Tiptap) State & Logic
+  // ----------------------------------------------------
+  const editorBoxRef = useRef(null);
+  const [editorPopover, setEditorPopover] = useState({
+    isOpen: false,
+    query: "",
+    selectedIndex: 0,
+    position: { top: 0, left: 0 },
+  });
+
+  const editorPopoverRef = useRef(editorPopover);
+  useEffect(() => {
+    editorPopoverRef.current = editorPopover;
+  }, [editorPopover]);
+
+  const checkEditorAutocomplete = useCallback((editorInstance) => {
+    if (!editorInstance || !editorBoxRef.current) return;
+    const { state, view } = editorInstance;
+    const { selection } = state;
+    const { from, empty } = selection;
+
+    if (!empty) {
+      setEditorPopover((prev) => ({ ...prev, isOpen: false }));
+      return;
+    }
+
+    const textBefore = state.doc.textBetween(Math.max(0, from - 50), from);
+    const lastOpenIndex = textBefore.lastIndexOf("{{");
+
+    if (lastOpenIndex !== -1) {
+      const queryText = textBefore.slice(lastOpenIndex + 2);
+      if (!queryText.includes("}") && !queryText.includes("\n")) {
+        const coords = view.coordsAtPos(from);
+        const containerRect = editorBoxRef.current.getBoundingClientRect();
+
+        const top = coords.bottom - containerRect.top + 4;
+        const left = Math.max(0, Math.min(coords.left - containerRect.left, containerRect.width - 330));
+
+        setEditorPopover({
+          isOpen: true,
+          query: queryText,
+          selectedIndex: 0,
+          position: { top, left },
+        });
+        return;
+      }
+    }
+
+    setEditorPopover((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const selectEditorOption = useCallback((option, viewInstance) => {
+    if (!viewInstance || !option) return;
+
+    const { state } = viewInstance;
+    const { selection } = state;
+    const { from } = selection;
+
+    const textBefore = state.doc.textBetween(Math.max(0, from - 50), from);
+    const lastOpenIndex = textBefore.lastIndexOf("{{");
+    if (lastOpenIndex === -1) return;
+
+    const startPos = from - (textBefore.length - lastOpenIndex);
+
+    let endPos = from;
+    const textAfter = state.doc.textBetween(from, Math.min(state.doc.content.size, from + 2));
+    if (textAfter === "}}") {
+      endPos = from + 2;
+    }
+
+    const replacementText = `{{${option.label}}}`;
+    const tr = state.tr.replaceWith(
+      startPos,
+      endPos,
+      state.schema.text(replacementText)
+    );
+
+    const newCursorPos = startPos + replacementText.length;
+    tr.setSelection(TextSelection.create(tr.doc, newCursorPos));
+    viewInstance.dispatch(tr);
+    viewInstance.focus();
+
+    setEditorPopover({ isOpen: false, query: "", selectedIndex: 0, position: { top: 0, left: 0 } });
+  }, []);
+
   // Rich text editor setup
   const editor = useEditor({
     extensions: [
@@ -27,8 +261,74 @@ export const NewTemplateSection = ({
     ],
     content: templateContent || "<p></p>",
     editable: isEditable,
+    editorProps: {
+      handleKeyDown: (view, event) => {
+        if (!isEditable) return false;
+        const { state } = view;
+        const { selection } = state;
+        const { from, empty } = selection;
+
+        // Auto-close double curly braces in editor
+        if (event.key === "{" && empty) {
+          const textBefore = state.doc.textBetween(Math.max(0, from - 1), from);
+          if (textBefore === "{") {
+            event.preventDefault();
+            // Insert '{}}' at cursor
+            const tr = state.tr.insertText("{}}");
+            view.dispatch(tr);
+
+            // Move cursor inside braces '{{|}}'
+            const currentSelection = view.state.selection;
+            const newPos = currentSelection.from - 2;
+            const selectTr = view.state.tr.setSelection(
+              TextSelection.create(view.state.doc, newPos)
+            );
+            view.dispatch(selectTr);
+            return true;
+          }
+        }
+
+        const currentPopover = editorPopoverRef.current;
+        if (currentPopover.isOpen) {
+          const filtered = getFilteredOptions(currentPopover.query);
+          if (filtered.length > 0) {
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setEditorPopover((prev) => ({
+                ...prev,
+                selectedIndex: (prev.selectedIndex + 1) % filtered.length,
+              }));
+              return true;
+            }
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setEditorPopover((prev) => ({
+                ...prev,
+                selectedIndex: (prev.selectedIndex - 1 + filtered.length) % filtered.length,
+              }));
+              return true;
+            }
+            if (event.key === "Enter" || event.key === "Tab") {
+              event.preventDefault();
+              selectEditorOption(filtered[currentPopover.selectedIndex], view);
+              return true;
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setEditorPopover((prev) => ({ ...prev, isOpen: false }));
+              return true;
+            }
+          }
+        }
+        return false;
+      },
+    },
     onUpdate: ({ editor }) => {
       setTemplateContent(editor.getHTML());
+      checkEditorAutocomplete(editor);
+    },
+    onSelectionUpdate: ({ editor }) => {
+      checkEditorAutocomplete(editor);
     },
     shouldRerenderOnTransaction: true,
     immediatelyRender: false,
@@ -36,13 +336,11 @@ export const NewTemplateSection = ({
 
   useEffect(() => {
     if (!editor) return;
-
     editor.setEditable(isEditable);
   }, [editor, isEditable]);
 
   useEffect(() => {
     if (!editor) return;
-
     const nextContent = templateContent || "<p></p>";
     if (editor.getHTML() !== nextContent) {
       editor.commands.setContent(nextContent, false);
@@ -65,26 +363,41 @@ export const NewTemplateSection = ({
         flex="1"
         minH={0}
       >
-          <VStack align="stretch" spacing={2}>
-            <Text fontSize="14px" fontWeight="600" color="#18181B">
-              Subject line
-            </Text>
-            <Input
-              value={templateSubject}
-              onChange={(e) => setTemplateSubject(e.target.value)}
-              placeholder="Enter subject line"
-              readOnly={!isEditable}
-              cursor={isEditable ? "text" : "default"}
-              h="40px"
-              borderColor="#E4E4E7"
-              borderWidth="1px"
-              borderRadius="5px"
-              bg="white"
-              _readOnly={{ bg: "white", opacity: 1, cursor: "default" }}
-              _focusVisible={{ borderColor: "#487C9E", boxShadow: "0 0 0 1px #487C9E" }}
-            />
-          </VStack>
+        <VStack align="stretch" spacing={2} ref={subjectContainerRef} position="relative">
+          <Text fontSize="14px" fontWeight="600" color="#18181B">
+            Subject line
+          </Text>
+          <Input
+            ref={subjectInputRef}
+            value={templateSubject}
+            onChange={handleSubjectChange}
+            onKeyDown={handleSubjectKeyDown}
+            onClick={handleSubjectClick}
+            placeholder="Enter subject line (type {{ for variables)"
+            readOnly={!isEditable}
+            cursor={isEditable ? "text" : "default"}
+            h="40px"
+            borderColor="#E4E4E7"
+            borderWidth="1px"
+            borderRadius="5px"
+            bg="white"
+            _readOnly={{ bg: "white", opacity: 1, cursor: "default" }}
+            _focusVisible={{ borderColor: "#487C9E", boxShadow: "0 0 0 1px #487C9E" }}
+          />
+
+          {/* Autocomplete popover for Subject line */}
+          <VariableAutocompletePopover
+            isOpen={subjectPopover.isOpen}
+            filterQuery={subjectPopover.query}
+            selectedIndex={subjectPopover.selectedIndex}
+            onSelectOption={selectSubjectOption}
+            position={subjectPopover.position}
+          />
+        </VStack>
+
         <Box
+          ref={editorBoxRef}
+          position="relative"
           bg="white"
           border="1px solid"
           borderColor="#E4E4E7"
@@ -136,6 +449,15 @@ export const NewTemplateSection = ({
               />
             </Box>
           </RichTextEditor.Root>
+
+          {/* Autocomplete popover for Rich Text Editor body */}
+          <VariableAutocompletePopover
+            isOpen={editorPopover.isOpen}
+            filterQuery={editorPopover.query}
+            selectedIndex={editorPopover.selectedIndex}
+            onSelectOption={(option) => selectEditorOption(option, editor.view)}
+            position={editorPopover.position}
+          />
         </Box>
       </VStack>
     </Box>

--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -12,6 +12,20 @@ import { TextSelection } from "@tiptap/pm/state";
 
 import { VariableAutocompletePopover, AVAILABLE_VARIABLES } from "./VariableAutocompletePopover";
 
+const POPOVER_WIDTH = 320;
+const POPOVER_MARGIN = 8;
+const POPOVER_OFFSET_Y = 4;
+
+const computePopoverPosition = (targetRect) => {
+  if (!targetRect) return { top: 0, left: 0 };
+  const top = targetRect.bottom + POPOVER_OFFSET_Y;
+  const left = Math.max(
+    POPOVER_MARGIN,
+    Math.min(targetRect.left, window.innerWidth - POPOVER_WIDTH - 10)
+  );
+  return { top, left };
+};
+
 export const NewTemplateSection = ({
   templateSubject,
   setTemplateSubject,
@@ -44,20 +58,16 @@ export const NewTemplateSection = ({
     if (lastOpenIndex !== -1) {
       const textBetween = textBefore.slice(lastOpenIndex + 2);
       if (!textBetween.includes("}") && !textBetween.includes("\n")) {
-        let top = 0;
-        let left = 0;
-        if (subjectInputRef.current) {
-          const rect = subjectInputRef.current.getBoundingClientRect();
-          top = rect.bottom + 4;
-          left = Math.max(8, Math.min(rect.left, window.innerWidth - 330));
-        }
+        const position = subjectInputRef.current
+          ? computePopoverPosition(subjectInputRef.current.getBoundingClientRect())
+          : { top: 0, left: 0 };
 
         setSubjectPopover((prev) => ({
           ...prev,
           isOpen: true,
           query: textBetween,
           selectedIndex: 0,
-          position: { top, left },
+          position,
         }));
         return;
       }
@@ -223,15 +233,13 @@ export const NewTemplateSection = ({
     if (lastOpenIndex !== -1) {
       const queryText = textBefore.slice(lastOpenIndex + 2);
       if (!queryText.includes("}") && !queryText.includes("\n")) {
-        const coords = view.coordsAtPos(from);
-        const top = coords.bottom + 4;
-        const left = Math.max(8, Math.min(coords.left, window.innerWidth - 330));
+        const position = computePopoverPosition(view.coordsAtPos(from));
 
         setEditorPopover({
           isOpen: true,
           query: queryText,
           selectedIndex: 0,
-          position: { top, left },
+          position,
         });
         return;
       }
@@ -248,11 +256,9 @@ export const NewTemplateSection = ({
 
     if (!empty) return;
 
-    const coords = view.coordsAtPos(from);
-    const top = coords.bottom + 4;
-    const left = Math.max(8, Math.min(coords.left, window.innerWidth - 330));
+    const position = computePopoverPosition(view.coordsAtPos(from));
 
-    setEditorPopover((prev) => (prev.isOpen ? { ...prev, position: { top, left } } : prev));
+    setEditorPopover((prev) => (prev.isOpen ? { ...prev, position } : prev));
   }, []);
 
   const selectEditorOption = useCallback((option, viewInstance) => {
@@ -412,10 +418,8 @@ export const NewTemplateSection = ({
 
     const handleScrollOrResize = () => {
       if (subjectPopover.isOpen && subjectInputRef.current) {
-        const rect = subjectInputRef.current.getBoundingClientRect();
-        const top = rect.bottom + 4;
-        const left = Math.max(8, Math.min(rect.left, window.innerWidth - 330));
-        setSubjectPopover((prev) => ({ ...prev, position: { top, left } }));
+        const position = computePopoverPosition(subjectInputRef.current.getBoundingClientRect());
+        setSubjectPopover((prev) => ({ ...prev, position }));
       }
       if (editorPopover.isOpen && editor?.view) {
         updateEditorPopoverPosition(editor);

--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -44,12 +44,20 @@ export const NewTemplateSection = ({
     if (lastOpenIndex !== -1) {
       const textBetween = textBefore.slice(lastOpenIndex + 2);
       if (!textBetween.includes("}") && !textBetween.includes("\n")) {
+        let top = 0;
+        let left = 0;
+        if (subjectInputRef.current) {
+          const rect = subjectInputRef.current.getBoundingClientRect();
+          top = rect.bottom + 4;
+          left = Math.max(8, Math.min(rect.left, window.innerWidth - 330));
+        }
+
         setSubjectPopover((prev) => ({
           ...prev,
           isOpen: true,
           query: textBetween,
           selectedIndex: 0,
-          position: { top: 44, left: 0 }, // Position right beneath input box
+          position: { top, left },
         }));
         return;
       }
@@ -66,8 +74,13 @@ export const NewTemplateSection = ({
     const lastOpenIndex = textBefore.lastIndexOf("{{");
     if (lastOpenIndex === -1) return;
 
+    // Detect and consume any existing suffix and closing braces '}}'
     let afterIndex = selectionStart;
-    if (value.slice(selectionStart, selectionStart + 2) === "}}") {
+    const textAfter = value.slice(selectionStart);
+    const closingMatch = textAfter.match(/^([^}\s]*\}\})/);
+    if (closingMatch) {
+      afterIndex = selectionStart + closingMatch[0].length;
+    } else if (textAfter.startsWith("}}")) {
       afterIndex = selectionStart + 2;
     }
 
@@ -164,6 +177,13 @@ export const NewTemplateSection = ({
     }
   };
 
+  const handleSubjectBlur = () => {
+    // Delay slightly to allow option click handlers to execute before closing
+    setTimeout(() => {
+      setSubjectPopover((prev) => (prev.isOpen ? { ...prev, isOpen: false } : prev));
+    }, 150);
+  };
+
   // ----------------------------------------------------
   // Rich Text Editor (Tiptap) State & Logic
   // ----------------------------------------------------
@@ -198,10 +218,8 @@ export const NewTemplateSection = ({
       const queryText = textBefore.slice(lastOpenIndex + 2);
       if (!queryText.includes("}") && !queryText.includes("\n")) {
         const coords = view.coordsAtPos(from);
-        const containerRect = editorBoxRef.current.getBoundingClientRect();
-
-        const top = coords.bottom - containerRect.top + 4;
-        const left = Math.max(0, Math.min(coords.left - containerRect.left, containerRect.width - 330));
+        const top = coords.bottom + 4;
+        const left = Math.max(8, Math.min(coords.left, window.innerWidth - 330));
 
         setEditorPopover({
           isOpen: true,
@@ -229,9 +247,14 @@ export const NewTemplateSection = ({
 
     const startPos = from - (textBefore.length - lastOpenIndex);
 
+    // Consume any existing suffix and closing '}}' in editor text
+    const maxCheck = Math.min(state.doc.content.size, from + 100);
+    const textAfter = state.doc.textBetween(from, maxCheck);
     let endPos = from;
-    const textAfter = state.doc.textBetween(from, Math.min(state.doc.content.size, from + 2));
-    if (textAfter === "}}") {
+    const closingMatch = textAfter.match(/^([^}\n]*\}\})/);
+    if (closingMatch) {
+      endPos = from + closingMatch[0].length;
+    } else if (textAfter.startsWith("}}")) {
       endPos = from + 2;
     }
 
@@ -248,6 +271,27 @@ export const NewTemplateSection = ({
     viewInstance.focus();
 
     setEditorPopover({ isOpen: false, query: "", selectedIndex: 0, position: { top: 0, left: 0 } });
+  }, []);
+
+  // Close popovers on outside clicks
+  useEffect(() => {
+    const handleGlobalMouseDown = (e) => {
+      if (
+        subjectContainerRef.current &&
+        !subjectContainerRef.current.contains(e.target)
+      ) {
+        setSubjectPopover((prev) => (prev.isOpen ? { ...prev, isOpen: false } : prev));
+      }
+      if (
+        editorBoxRef.current &&
+        !editorBoxRef.current.contains(e.target)
+      ) {
+        setEditorPopover((prev) => (prev.isOpen ? { ...prev, isOpen: false } : prev));
+      }
+    };
+
+    document.addEventListener("mousedown", handleGlobalMouseDown);
+    return () => document.removeEventListener("mousedown", handleGlobalMouseDown);
   }, []);
 
   // Rich text editor setup
@@ -349,6 +393,9 @@ export const NewTemplateSection = ({
 
   if (!editor) return null;
 
+  const currentSubjectFiltered = getFilteredOptions(subjectPopover.query);
+  const currentSubjectSelected = currentSubjectFiltered[subjectPopover.selectedIndex];
+
   return (
     <Box
       width="100%"
@@ -373,6 +420,15 @@ export const NewTemplateSection = ({
             onChange={handleSubjectChange}
             onKeyDown={handleSubjectKeyDown}
             onClick={handleSubjectClick}
+            onBlur={handleSubjectBlur}
+            aria-autocomplete="list"
+            aria-expanded={subjectPopover.isOpen}
+            aria-controls={subjectPopover.isOpen ? "variable-autocomplete-listbox" : undefined}
+            aria-activedescendant={
+              subjectPopover.isOpen && currentSubjectSelected
+                ? `variable-option-${subjectPopover.selectedIndex}`
+                : undefined
+            }
             placeholder="Enter subject line (type {{ for variables)"
             readOnly={!isEditable}
             cursor={isEditable ? "text" : "default"}

--- a/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
+++ b/client/src/components/emailTemplateManagement/components/NewTemplateSection.jsx
@@ -177,8 +177,14 @@ export const NewTemplateSection = ({
     }
   };
 
-  const handleSubjectBlur = () => {
-    // Delay slightly to allow option click handlers to execute before closing
+  const handleSubjectBlur = (e) => {
+    if (
+      e?.relatedTarget &&
+      (e.relatedTarget.closest("#variable-autocomplete-listbox") ||
+        e.relatedTarget.closest("[role='listbox']"))
+    ) {
+      return;
+    }
     setTimeout(() => {
       setSubjectPopover((prev) => (prev.isOpen ? { ...prev, isOpen: false } : prev));
     }, 150);
@@ -276,6 +282,13 @@ export const NewTemplateSection = ({
   // Close popovers on outside clicks
   useEffect(() => {
     const handleGlobalMouseDown = (e) => {
+      // Ignore clicks inside the autocomplete popover listbox
+      if (
+        e.target.closest("#variable-autocomplete-listbox") ||
+        e.target.closest("[role='listbox']")
+      ) {
+        return;
+      }
       if (
         subjectContainerRef.current &&
         !subjectContainerRef.current.contains(e.target)
@@ -378,6 +391,30 @@ export const NewTemplateSection = ({
     immediatelyRender: false,
   });
 
+  // Update popover coordinates on scroll or window resize
+  useEffect(() => {
+    if (!subjectPopover.isOpen && !editorPopover.isOpen) return;
+
+    const handleScrollOrResize = () => {
+      if (subjectPopover.isOpen && subjectInputRef.current) {
+        const rect = subjectInputRef.current.getBoundingClientRect();
+        const top = rect.bottom + 4;
+        const left = Math.max(8, Math.min(rect.left, window.innerWidth - 330));
+        setSubjectPopover((prev) => ({ ...prev, position: { top, left } }));
+      }
+      if (editorPopover.isOpen && editor?.view) {
+        checkEditorAutocomplete(editor);
+      }
+    };
+
+    window.addEventListener("scroll", handleScrollOrResize, true);
+    window.addEventListener("resize", handleScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", handleScrollOrResize, true);
+      window.removeEventListener("resize", handleScrollOrResize);
+    };
+  }, [subjectPopover.isOpen, editorPopover.isOpen, checkEditorAutocomplete, editor]);
+
   useEffect(() => {
     if (!editor) return;
     editor.setEditable(isEditable);
@@ -394,7 +431,10 @@ export const NewTemplateSection = ({
   if (!editor) return null;
 
   const currentSubjectFiltered = getFilteredOptions(subjectPopover.query);
-  const currentSubjectSelected = currentSubjectFiltered[subjectPopover.selectedIndex];
+  const isSubjectPopoverVisible = subjectPopover.isOpen && currentSubjectFiltered.length > 0;
+  const currentSubjectSelected = isSubjectPopoverVisible
+    ? currentSubjectFiltered[subjectPopover.selectedIndex]
+    : null;
 
   return (
     <Box
@@ -422,10 +462,10 @@ export const NewTemplateSection = ({
             onClick={handleSubjectClick}
             onBlur={handleSubjectBlur}
             aria-autocomplete="list"
-            aria-expanded={subjectPopover.isOpen}
-            aria-controls={subjectPopover.isOpen ? "variable-autocomplete-listbox" : undefined}
+            aria-expanded={isSubjectPopoverVisible}
+            aria-controls={isSubjectPopoverVisible ? "variable-autocomplete-listbox" : undefined}
             aria-activedescendant={
-              subjectPopover.isOpen && currentSubjectSelected
+              isSubjectPopoverVisible && currentSubjectSelected
                 ? `variable-option-${subjectPopover.selectedIndex}`
                 : undefined
             }

--- a/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
+++ b/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
@@ -1,0 +1,287 @@
+import React, { useEffect, useRef } from "react";
+import { Box, Flex, Text, Badge } from "@chakra-ui/react";
+import { User, Building2, Variable } from "lucide-react";
+
+export const AVAILABLE_VARIABLES = [
+  // Volunteer variables
+  {
+    key: "name",
+    label: "name",
+    category: "Volunteer",
+    table: "volunteers",
+    description: "Volunteer's full name",
+    badgeBg: "#E0F2FE",
+    badgeColor: "#0369A1",
+    icon: User,
+  },
+  {
+    key: "volunteer name",
+    label: "volunteer name",
+    category: "Volunteer",
+    table: "volunteers",
+    description: "Alias for volunteer's full name",
+    badgeBg: "#E0F2FE",
+    badgeColor: "#0369A1",
+    icon: User,
+  },
+  {
+    key: "email",
+    label: "email",
+    category: "Volunteer",
+    table: "volunteers",
+    description: "Volunteer's email address",
+    badgeBg: "#E0F2FE",
+    badgeColor: "#0369A1",
+    icon: User,
+  },
+  // Clinic variables
+  {
+    key: "clinic name",
+    label: "clinic name",
+    category: "Clinic",
+    table: "clinics",
+    description: "Name of the clinic",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "date",
+    label: "date",
+    category: "Clinic",
+    table: "clinics",
+    description: "Formatted clinic date",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "time",
+    label: "time",
+    category: "Clinic",
+    table: "clinics",
+    description: "Formatted start & end time",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "location",
+    label: "location",
+    category: "Clinic",
+    table: "clinics",
+    description: "Full clinic address (address, city, state, zip)",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "parking",
+    label: "parking",
+    category: "Clinic",
+    table: "clinics",
+    description: "Parking instructions for volunteers",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "meeting link",
+    label: "meeting link",
+    category: "Clinic",
+    table: "clinics",
+    description: "Virtual meeting URL",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+  {
+    key: "description",
+    label: "description",
+    category: "Clinic",
+    table: "clinics",
+    description: "Clinic summary and details",
+    badgeBg: "#F3E8FF",
+    badgeColor: "#6B21A8",
+    icon: Building2,
+  },
+];
+
+export const VariableAutocompletePopover = ({
+  isOpen,
+  filterQuery = "",
+  selectedIndex = 0,
+  onSelectOption,
+  position = { top: 0, left: 0 },
+}) => {
+  const containerRef = useRef(null);
+
+  const filteredOptions = AVAILABLE_VARIABLES.filter((item) =>
+    item.label.toLowerCase().includes(filterQuery.trim().toLowerCase())
+  );
+
+  // Group by category for visual organization
+  const volunteerItems = filteredOptions.filter(
+    (item) => item.category === "Volunteer"
+  );
+  const clinicItems = filteredOptions.filter(
+    (item) => item.category === "Clinic"
+  );
+
+  useEffect(() => {
+    // Scroll selected item into view inside popover container
+    if (!containerRef.current) return;
+    const selectedEl = containerRef.current.querySelector(
+      `[data-option-index="${selectedIndex}"]`
+    );
+    if (selectedEl) {
+      selectedEl.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  if (!isOpen || filteredOptions.length === 0) return null;
+
+  let globalIndexCounter = 0;
+
+  return (
+    <Box
+      ref={containerRef}
+      position="absolute"
+      top={`${position.top}px`}
+      left={`${position.left}px`}
+      zIndex={9999}
+      width="320px"
+      maxH="280px"
+      overflowY="auto"
+      bg="white"
+      borderRadius="8px"
+      border="1px solid #E4E4E7"
+      boxShadow="0px 10px 25px -5px rgba(0, 0, 0, 0.1), 0px 8px 10px -6px rgba(0, 0, 0, 0.1)"
+      py="6px"
+      px="4px"
+      onMouseDown={(e) => e.preventDefault()} // Prevent blur when clicking
+    >
+      <Flex
+        px="10px"
+        py="4px"
+        align="center"
+        gap="6px"
+        borderBottom="1px solid #F4F4F5"
+        mb="4px"
+      >
+        <Variable size={13} color="#71717A" />
+        <Text fontSize="11px" fontWeight="600" color="#71717A" letterSpacing="0.5px" textTransform="uppercase">
+          Insert Template Variable
+        </Text>
+      </Flex>
+
+      {/* Volunteer Section */}
+      {volunteerItems.length > 0 && (
+        <Box mb="6px">
+          <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#0369A1" bg="#F0F9FF">
+            👤 VOLUNTEER TABLE
+          </Text>
+          {volunteerItems.map((item) => {
+            const currentIndex = globalIndexCounter++;
+            const isSelected = currentIndex === selectedIndex;
+            const IconComp = item.icon;
+            return (
+              <Flex
+                key={item.key}
+                data-option-index={currentIndex}
+                align="center"
+                justify="space-between"
+                px="10px"
+                py="6px"
+                my="1px"
+                borderRadius="6px"
+                cursor="pointer"
+                bg={isSelected ? "#E0F2FE" : "transparent"}
+                _hover={{ bg: "#F0F9FF" }}
+                onClick={() => onSelectOption(item)}
+              >
+                <Flex align="center" gap="8px" minW={0}>
+                  <IconComp size={14} color="#0284C7" style={{ flexShrink: 0 }} />
+                  <Box minW={0}>
+                    <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
+                      {`{{${item.label}}}`}
+                    </Text>
+                    <Text fontSize="11px" color="#64748B" truncate>
+                      {item.description}
+                    </Text>
+                  </Box>
+                </Flex>
+                <Badge
+                  fontSize="10px"
+                  fontWeight="600"
+                  px="6px"
+                  py="1px"
+                  borderRadius="4px"
+                  bg={item.badgeBg}
+                  color={item.badgeColor}
+                  flexShrink={0}
+                >
+                  Volunteer
+                </Badge>
+              </Flex>
+            );
+          })}
+        </Box>
+      )}
+
+      {/* Clinic Section */}
+      {clinicItems.length > 0 && (
+        <Box>
+          <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#6B21A8" bg="#FAF5FF">
+            🏥 CLINIC TABLE
+          </Text>
+          {clinicItems.map((item) => {
+            const currentIndex = globalIndexCounter++;
+            const isSelected = currentIndex === selectedIndex;
+            const IconComp = item.icon;
+            return (
+              <Flex
+                key={item.key}
+                data-option-index={currentIndex}
+                align="center"
+                justify="space-between"
+                px="10px"
+                py="6px"
+                my="1px"
+                borderRadius="6px"
+                cursor="pointer"
+                bg={isSelected ? "#F3E8FF" : "transparent"}
+                _hover={{ bg: "#FAF5FF" }}
+                onClick={() => onSelectOption(item)}
+              >
+                <Flex align="center" gap="8px" minW={0}>
+                  <IconComp size={14} color="#9333EA" style={{ flexShrink: 0 }} />
+                  <Box minW={0}>
+                    <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
+                      {`{{${item.label}}}`}
+                    </Text>
+                    <Text fontSize="11px" color="#64748B" truncate>
+                      {item.description}
+                    </Text>
+                  </Box>
+                </Flex>
+                <Badge
+                  fontSize="10px"
+                  fontWeight="600"
+                  px="6px"
+                  py="1px"
+                  borderRadius="4px"
+                  bg={item.badgeBg}
+                  color={item.badgeColor}
+                  flexShrink={0}
+                >
+                  Clinic
+                </Badge>
+              </Flex>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
+++ b/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
@@ -215,6 +215,10 @@ export const VariableAutocompletePopover = ({
                   cursor="pointer"
                   bg={isSelected ? "#E0F2FE" : "transparent"}
                   _hover={{ bg: "#F0F9FF" }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSelectOption(item);
+                  }}
                   onClick={() => onSelectOption(item)}
                 >
                   <Flex align="center" gap="8px" minW={0}>
@@ -272,6 +276,10 @@ export const VariableAutocompletePopover = ({
                   cursor="pointer"
                   bg={isSelected ? "#F3E8FF" : "transparent"}
                   _hover={{ bg: "#FAF5FF" }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSelectOption(item);
+                  }}
                   onClick={() => onSelectOption(item)}
                 >
                   <Flex align="center" gap="8px" minW={0}>

--- a/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
+++ b/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
@@ -219,7 +219,6 @@ export const VariableAutocompletePopover = ({
                     e.preventDefault();
                     onSelectOption(item);
                   }}
-                  onClick={() => onSelectOption(item)}
                 >
                   <Flex align="center" gap="8px" minW={0}>
                     <IconComp size={14} color="#0284C7" style={{ flexShrink: 0 }} />
@@ -280,7 +279,6 @@ export const VariableAutocompletePopover = ({
                     e.preventDefault();
                     onSelectOption(item);
                   }}
-                  onClick={() => onSelectOption(item)}
                 >
                   <Flex align="center" gap="8px" minW={0}>
                     <IconComp size={14} color="#9333EA" style={{ flexShrink: 0 }} />

--- a/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
+++ b/client/src/components/emailTemplateManagement/components/VariableAutocompletePopover.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Box, Flex, Text, Badge } from "@chakra-ui/react";
+import { Box, Flex, Text, Badge, Portal } from "@chakra-ui/react";
 import { User, Building2, Variable } from "lucide-react";
 
 export const AVAILABLE_VARIABLES = [
@@ -30,6 +30,16 @@ export const AVAILABLE_VARIABLES = [
     category: "Volunteer",
     table: "volunteers",
     description: "Volunteer's email address",
+    badgeBg: "#E0F2FE",
+    badgeColor: "#0369A1",
+    icon: User,
+  },
+  {
+    key: "volunteer email",
+    label: "volunteer email",
+    category: "Volunteer",
+    table: "volunteers",
+    description: "Alias for volunteer's email address",
     badgeBg: "#E0F2FE",
     badgeColor: "#0369A1",
     icon: User,
@@ -144,144 +154,155 @@ export const VariableAutocompletePopover = ({
   let globalIndexCounter = 0;
 
   return (
-    <Box
-      ref={containerRef}
-      position="absolute"
-      top={`${position.top}px`}
-      left={`${position.left}px`}
-      zIndex={9999}
-      width="320px"
-      maxH="280px"
-      overflowY="auto"
-      bg="white"
-      borderRadius="8px"
-      border="1px solid #E4E4E7"
-      boxShadow="0px 10px 25px -5px rgba(0, 0, 0, 0.1), 0px 8px 10px -6px rgba(0, 0, 0, 0.1)"
-      py="6px"
-      px="4px"
-      onMouseDown={(e) => e.preventDefault()} // Prevent blur when clicking
-    >
-      <Flex
-        px="10px"
-        py="4px"
-        align="center"
-        gap="6px"
-        borderBottom="1px solid #F4F4F5"
-        mb="4px"
+    <Portal>
+      <Box
+        ref={containerRef}
+        role="listbox"
+        id="variable-autocomplete-listbox"
+        aria-label="Insert Template Variable"
+        position="fixed"
+        top={`${position.top}px`}
+        left={`${position.left}px`}
+        zIndex={99999}
+        width="320px"
+        maxH="280px"
+        overflowY="auto"
+        bg="white"
+        borderRadius="8px"
+        border="1px solid #E4E4E7"
+        boxShadow="0px 10px 25px -5px rgba(0, 0, 0, 0.15), 0px 8px 10px -6px rgba(0, 0, 0, 0.1)"
+        py="6px"
+        px="4px"
+        onMouseDown={(e) => e.preventDefault()} // Prevent blur when clicking options
       >
-        <Variable size={13} color="#71717A" />
-        <Text fontSize="11px" fontWeight="600" color="#71717A" letterSpacing="0.5px" textTransform="uppercase">
-          Insert Template Variable
-        </Text>
-      </Flex>
-
-      {/* Volunteer Section */}
-      {volunteerItems.length > 0 && (
-        <Box mb="6px">
-          <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#0369A1" bg="#F0F9FF">
-            👤 VOLUNTEER TABLE
+        <Flex
+          px="10px"
+          py="4px"
+          align="center"
+          gap="6px"
+          borderBottom="1px solid #F4F4F5"
+          mb="4px"
+        >
+          <Variable size={13} color="#71717A" />
+          <Text fontSize="11px" fontWeight="600" color="#71717A" letterSpacing="0.5px" textTransform="uppercase">
+            Insert Template Variable
           </Text>
-          {volunteerItems.map((item) => {
-            const currentIndex = globalIndexCounter++;
-            const isSelected = currentIndex === selectedIndex;
-            const IconComp = item.icon;
-            return (
-              <Flex
-                key={item.key}
-                data-option-index={currentIndex}
-                align="center"
-                justify="space-between"
-                px="10px"
-                py="6px"
-                my="1px"
-                borderRadius="6px"
-                cursor="pointer"
-                bg={isSelected ? "#E0F2FE" : "transparent"}
-                _hover={{ bg: "#F0F9FF" }}
-                onClick={() => onSelectOption(item)}
-              >
-                <Flex align="center" gap="8px" minW={0}>
-                  <IconComp size={14} color="#0284C7" style={{ flexShrink: 0 }} />
-                  <Box minW={0}>
-                    <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
-                      {`{{${item.label}}}`}
-                    </Text>
-                    <Text fontSize="11px" color="#64748B" truncate>
-                      {item.description}
-                    </Text>
-                  </Box>
-                </Flex>
-                <Badge
-                  fontSize="10px"
-                  fontWeight="600"
-                  px="6px"
-                  py="1px"
-                  borderRadius="4px"
-                  bg={item.badgeBg}
-                  color={item.badgeColor}
-                  flexShrink={0}
-                >
-                  Volunteer
-                </Badge>
-              </Flex>
-            );
-          })}
-        </Box>
-      )}
+        </Flex>
 
-      {/* Clinic Section */}
-      {clinicItems.length > 0 && (
-        <Box>
-          <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#6B21A8" bg="#FAF5FF">
-            🏥 CLINIC TABLE
-          </Text>
-          {clinicItems.map((item) => {
-            const currentIndex = globalIndexCounter++;
-            const isSelected = currentIndex === selectedIndex;
-            const IconComp = item.icon;
-            return (
-              <Flex
-                key={item.key}
-                data-option-index={currentIndex}
-                align="center"
-                justify="space-between"
-                px="10px"
-                py="6px"
-                my="1px"
-                borderRadius="6px"
-                cursor="pointer"
-                bg={isSelected ? "#F3E8FF" : "transparent"}
-                _hover={{ bg: "#FAF5FF" }}
-                onClick={() => onSelectOption(item)}
-              >
-                <Flex align="center" gap="8px" minW={0}>
-                  <IconComp size={14} color="#9333EA" style={{ flexShrink: 0 }} />
-                  <Box minW={0}>
-                    <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
-                      {`{{${item.label}}}`}
-                    </Text>
-                    <Text fontSize="11px" color="#64748B" truncate>
-                      {item.description}
-                    </Text>
-                  </Box>
-                </Flex>
-                <Badge
-                  fontSize="10px"
-                  fontWeight="600"
-                  px="6px"
-                  py="1px"
-                  borderRadius="4px"
-                  bg={item.badgeBg}
-                  color={item.badgeColor}
-                  flexShrink={0}
+        {/* Volunteer Section */}
+        {volunteerItems.length > 0 && (
+          <Box mb="6px">
+            <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#0369A1" bg="#F0F9FF">
+              👤 VOLUNTEER TABLE
+            </Text>
+            {volunteerItems.map((item) => {
+              const currentIndex = globalIndexCounter++;
+              const isSelected = currentIndex === selectedIndex;
+              const IconComp = item.icon;
+              return (
+                <Flex
+                  key={item.key}
+                  role="option"
+                  id={`variable-option-${currentIndex}`}
+                  aria-selected={isSelected}
+                  data-option-index={currentIndex}
+                  align="center"
+                  justify="space-between"
+                  px="10px"
+                  py="6px"
+                  my="1px"
+                  borderRadius="6px"
+                  cursor="pointer"
+                  bg={isSelected ? "#E0F2FE" : "transparent"}
+                  _hover={{ bg: "#F0F9FF" }}
+                  onClick={() => onSelectOption(item)}
                 >
-                  Clinic
-                </Badge>
-              </Flex>
-            );
-          })}
-        </Box>
-      )}
-    </Box>
+                  <Flex align="center" gap="8px" minW={0}>
+                    <IconComp size={14} color="#0284C7" style={{ flexShrink: 0 }} />
+                    <Box minW={0}>
+                      <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
+                        {`{{${item.label}}}`}
+                      </Text>
+                      <Text fontSize="11px" color="#64748B" truncate>
+                        {item.description}
+                      </Text>
+                    </Box>
+                  </Flex>
+                  <Badge
+                    fontSize="10px"
+                    fontWeight="600"
+                    px="6px"
+                    py="1px"
+                    borderRadius="4px"
+                    bg={item.badgeBg}
+                    color={item.badgeColor}
+                    flexShrink={0}
+                  >
+                    Volunteer
+                  </Badge>
+                </Flex>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* Clinic Section */}
+        {clinicItems.length > 0 && (
+          <Box>
+            <Text px="10px" py="3px" fontSize="11px" fontWeight="700" color="#6B21A8" bg="#FAF5FF">
+              🏥 CLINIC TABLE
+            </Text>
+            {clinicItems.map((item) => {
+              const currentIndex = globalIndexCounter++;
+              const isSelected = currentIndex === selectedIndex;
+              const IconComp = item.icon;
+              return (
+                <Flex
+                  key={item.key}
+                  role="option"
+                  id={`variable-option-${currentIndex}`}
+                  aria-selected={isSelected}
+                  data-option-index={currentIndex}
+                  align="center"
+                  justify="space-between"
+                  px="10px"
+                  py="6px"
+                  my="1px"
+                  borderRadius="6px"
+                  cursor="pointer"
+                  bg={isSelected ? "#F3E8FF" : "transparent"}
+                  _hover={{ bg: "#FAF5FF" }}
+                  onClick={() => onSelectOption(item)}
+                >
+                  <Flex align="center" gap="8px" minW={0}>
+                    <IconComp size={14} color="#9333EA" style={{ flexShrink: 0 }} />
+                    <Box minW={0}>
+                      <Text fontSize="13px" fontWeight="600" color="#0F172A" truncate>
+                        {`{{${item.label}}}`}
+                      </Text>
+                      <Text fontSize="11px" color="#64748B" truncate>
+                        {item.description}
+                      </Text>
+                    </Box>
+                  </Flex>
+                  <Badge
+                    fontSize="10px"
+                    fontWeight="600"
+                    px="6px"
+                    py="1px"
+                    borderRadius="4px"
+                    bg={item.badgeBg}
+                    color={item.badgeColor}
+                    flexShrink={0}
+                  >
+                    Clinic
+                  </Badge>
+                </Flex>
+              );
+            })}
+          </Box>
+        )}
+      </Box>
+    </Portal>
   );
 };

--- a/client/src/components/emailTemplateManagement/components/index.js
+++ b/client/src/components/emailTemplateManagement/components/index.js
@@ -14,3 +14,4 @@ export { DeleteTemplateModal } from "./DeleteTemplateModal";
 export { RenameFolderDialog } from "./RenameFolderDialog";
 export { ContextMenu } from "./ContextMenu";
 export { RenameDialog } from "./RenameDialog";
+export { VariableAutocompletePopover, AVAILABLE_VARIABLES } from "./VariableAutocompletePopover";

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -94,6 +94,7 @@ export const EmailTemplateManagement = () => {
   const [isLoadingFolders, setIsLoadingFolders] = useState(true);
   const [isLoadingTemplates, setIsLoadingTemplates] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showDiscardChangesModal, setShowDiscardChangesModal] = useState(false);
   const [showDeleteFolderModal, setShowDeleteFolderModal] = useState(false);
   const [showMoveTemplateModal, setShowMoveTemplateModal] = useState(false);
   const [moveFolderId, setMoveFolderId] = useState("");
@@ -332,7 +333,29 @@ export const EmailTemplateManagement = () => {
     normalizeEditorContent,
   ]);
 
-  const showEditModeDeleteButton = isEditingTemplate && !hasUnsavedChanges;
+  const handleConfirmCancelEdit = () => {
+    setTemplateName(initialTemplateSnapshot.name);
+    setTemplateSubject(initialTemplateSnapshot.subject);
+    setTemplateContent(initialTemplateSnapshot.content);
+    setIsEditingTemplate(false);
+
+    if (urlTemplateId && urlTemplateId.startsWith("new-")) {
+      if (activeFolderId) {
+        navigate(`/email/folder/${activeFolderId}`);
+      } else {
+        navigate("/email");
+      }
+    }
+    setShowDiscardChangesModal(false);
+  };
+
+  const handleCancelEditClick = () => {
+    if (hasUnsavedChanges) {
+      setShowDiscardChangesModal(true);
+    } else {
+      handleConfirmCancelEdit();
+    }
+  };
 
   const openMoveTemplateModalWithDefaultFolder = () => {
     const firstAvailableFolder = folders.find(
@@ -1110,51 +1133,45 @@ export const EmailTemplateManagement = () => {
                     {hasUnsavedChanges ? <Save size={16} /> : <Pencil size={16} />}
                     {hasUnsavedChanges ? "Save" : "Edit"}
                   </Button>
-
-                  <Button
-                    variant={showEditModeDeleteButton ? "solid" : "outline"}
-                    h="40px"
-                    px="16px"
-                    fontSize="14px"
-                    fontWeight="500"
-                    borderRadius="4px"
-                    borderWidth="1px"
-                    display="flex"
-                    gap="8px"
-                    alignItems="center"
-                    color={
-                      showEditModeDeleteButton
-                        ? "#18181B"
-                        : showMoveTemplateModal || showRenameDialog
-                          ? "black"
-                          : "#991919"
-                    }
-                    borderColor={
-                      showEditModeDeleteButton
-                        ? "#E4E4E7"
-                        : showMoveTemplateModal || showRenameDialog
-                          ? "#E4E4E7"
-                          : "#FECACA"
-                    }
-                    bg={
-                      showEditModeDeleteButton
-                        ? "#E4E4E7"
-                        : showMoveTemplateModal || showRenameDialog
-                          ? "#E4E4E7"
-                          : "transparent"
-                    }
-                    _hover={
-                      showEditModeDeleteButton
-                        ? { bg: "#E4E4E7" }
-                        : showMoveTemplateModal || showRenameDialog
-                          ? { bg: "#E4E4E7" }
-                          : { bg: "#FEE2E2" }
-                    }
-                    onClick={() => setShowDeleteModal(true)}
-                  >
-                    <Trash2 size={16} />
-                    Delete
-                  </Button>
+                  {isTemplateEditable ? (
+                    <Button
+                      variant="outline"
+                      h="40px"
+                      px="16px"
+                      fontSize="14px"
+                      fontWeight="500"
+                      borderRadius="4px"
+                      borderWidth="1px"
+                      borderColor="#E4E4E7"
+                      color="#27272A"
+                      bg="white"
+                      _hover={{ bg: "#F4F4F5" }}
+                      onClick={handleCancelEditClick}
+                    >
+                      Cancel
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      h="40px"
+                      px="16px"
+                      fontSize="14px"
+                      fontWeight="500"
+                      borderRadius="4px"
+                      borderWidth="1px"
+                      display="flex"
+                      gap="8px"
+                      alignItems="center"
+                      color="#991919"
+                      borderColor="#FECACA"
+                      bg="transparent"
+                      _hover={{ bg: "#FEE2E2" }}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      <Trash2 size={16} />
+                      Delete
+                    </Button>
+                  )}
                 </HStack>
               </HStack>
             </>
@@ -1385,6 +1402,58 @@ export const EmailTemplateManagement = () => {
         onClose={() => setShowDeleteModal(false)}
         onDelete={handleDeleteTemplate}
       />
+
+      {/* Discard Unsaved Changes Modal when Cancelling Edit Mode */}
+      <Dialog.Root
+        open={showDiscardChangesModal}
+        onOpenChange={(e) => setShowDiscardChangesModal(e.open)}
+        placement="center"
+      >
+        <Portal>
+          <Dialog.Backdrop bg="blackAlpha.400" />
+          <Dialog.Positioner>
+            <Dialog.Content
+              w="380px"
+              boxShadow="xl"
+              borderRadius="md"
+              p={0}
+              bg="white"
+            >
+              <Dialog.CloseTrigger position="absolute" top="0" right="0" asChild>
+                <CloseButton size="sm" onClick={() => setShowDiscardChangesModal(false)} />
+              </Dialog.CloseTrigger>
+              <Dialog.Body p={6}>
+                <VStack align="stretch" gap={4}>
+                  <Text fontSize="md" fontWeight="bold">
+                    Discard unsaved changes?
+                  </Text>
+                  <Text fontSize="sm" color="gray.600">
+                    Are you sure you want to cancel? Any unsaved edits will be lost.
+                  </Text>
+                  <HStack gap={3} justify="flex-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setShowDiscardChangesModal(false)}
+                    >
+                      Keep Editing
+                    </Button>
+                    <Button
+                      bg="#DC2626"
+                      color="white"
+                      size="sm"
+                      _hover={{ bg: "#B91C1C" }}
+                      onClick={handleConfirmCancelEdit}
+                    >
+                      Discard Changes
+                    </Button>
+                  </HStack>
+                </VStack>
+              </Dialog.Body>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
+      </Dialog.Root>
 
       {/* Confirm Delete Folder Dialog (top-level so it works from both header button and context menu) */}
       <Dialog.Root

--- a/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
+++ b/client/src/components/emailTemplateManagement/emailTemplateManagement.jsx
@@ -340,6 +340,7 @@ export const EmailTemplateManagement = () => {
     setIsEditingTemplate(false);
 
     if (urlTemplateId && urlTemplateId.startsWith("new-")) {
+      resetTemplateForm();
       if (activeFolderId) {
         navigate(`/email/folder/${activeFolderId}`);
       } else {
@@ -574,6 +575,7 @@ export const EmailTemplateManagement = () => {
   const handleRenameTemplate = async (templateId, newName) => {
     if (!templateId) {
       setTemplateName(newName);
+      setInitialTemplateSnapshot((prev) => ({ ...prev, name: newName }));
       return;
     }
 
@@ -587,7 +589,10 @@ export const EmailTemplateManagement = () => {
         subject: existing?.subject ?? null,
       });
 
-      setTemplateName((prev) => (String(currentTemplateId) === String(templateId) ? newName : prev));
+      if (String(currentTemplateId) === String(templateId)) {
+        setTemplateName(newName);
+        setInitialTemplateSnapshot((prev) => ({ ...prev, name: newName }));
+      }
       setTemplates((prev) =>
         prev.map((t) => (t.id === templateId ? { ...t, name: newName } : t))
       );

--- a/server/common/clinicEmailTemplate.js
+++ b/server/common/clinicEmailTemplate.js
@@ -49,6 +49,13 @@ const buildClinicTemplateVariables = (clinic, recipient = {}) => {
     typeof recipient.name === "string" && recipient.name.trim() !== ""
       ? recipient.name.trim()
       : null;
+  const recipientEmail =
+    typeof recipient.email === "string" && recipient.email.trim() !== ""
+      ? recipient.email.trim()
+      : null;
+
+  const nameVal = recipientName ? escapeHtml(recipientName) : "";
+  const emailVal = recipientEmail ? escapeHtml(recipientEmail) : "";
 
   const vars = {
     "clinic name": escapeHtml(clinic?.name),
@@ -58,7 +65,10 @@ const buildClinicTemplateVariables = (clinic, recipient = {}) => {
     location: escapeHtml(buildLocation(clinic) || "TBD"),
     parking: escapeHtml(clinic?.parking),
     "meeting link": escapeHtml(clinic?.meeting_link),
-    name: recipientName ? escapeHtml(recipientName) : "",
+    name: nameVal,
+    "volunteer name": nameVal,
+    email: emailVal,
+    "volunteer email": emailVal,
   };
 
   return vars;

--- a/server/routes/clinics.js
+++ b/server/routes/clinics.js
@@ -641,7 +641,7 @@ clinicsRouter.post(
             <p>Thanks for volunteering!</p>
           `,
               clinicInfo,
-              { name: safeName }
+              { name: safeName, email: volunteer.email }
             ),
           });
         }

--- a/server/routes/scheduler.js
+++ b/server/routes/scheduler.js
@@ -90,11 +90,13 @@ cron.schedule("0 * * * *", async () => {
       const renderedSubject = clinic
         ? renderClinicEmailTemplate(email.subject, clinic, {
             name: primaryRegistrant?.name,
+            email: primaryRegistrant?.email ?? email.to_email,
           })
         : email.subject;
       const renderedBody = clinic
         ? renderClinicEmailTemplate(bodyHtml, clinic, {
             name: primaryRegistrant?.name,
+            email: primaryRegistrant?.email ?? email.to_email,
           })
         : bodyHtml;
 
@@ -116,11 +118,13 @@ cron.schedule("0 * * * *", async () => {
             const perRecipientSubject = clinic
               ? renderClinicEmailTemplate(email.subject, clinic, {
                   name: recipient.name,
+                  email: recipient.email,
                 })
               : email.subject;
             const perRecipientBody = clinic
               ? renderClinicEmailTemplate(bodyHtml, clinic, {
                   name: recipient.name,
+                  email: recipient.email,
                 })
               : bodyHtml;
             try {


### PR DESCRIPTION
## Description
As title and issue suggests. Antigravity'd this QOL improvement for email templates

## Screenshots/Media
<img width="428" height="356" alt="image" src="https://github.com/user-attachments/assets/3ebdab26-d7a3-49b9-80ad-32995c907aad" />

## Issues
Closes #155 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an IDE-like variable autocomplete to email templates. Type {{ in the subject or body to open a keyboard-driven popup; includes auto-closing braces, server support for volunteer name/email, and replaces Delete with Cancel (with discard confirmation) in edit mode.

- **New Features**
  - Popup in subject and editor — filter-as-you-type, cursor-anchored, grouped by Volunteer/Clinic, ARIA listbox, portal positioned, and repositions on scroll/resize; full keyboard support.
  - "{{" auto-closes to "{{}}" and smart insertion consumes trailing tokens to avoid duplicates.
  - Server: added `name`/`volunteer name` and `email`/`volunteer email`; routes pass recipient email so `{{email}}` works in scheduler and clinic sends.
  - Edit mode: replaced Delete with Cancel and added a discard-changes confirmation.

- **Bug Fixes**
  - Fixed mouse selection and prevented double option selection; preserved popover scroll/selection index; resolved editor init reference error.
  - Synced draft state on template rename.
  - DRY popover position calculation and keep anchor stable during scroll/resize.

<sup>Written for commit e2f6a7e176cf3b05b77c5396030f101105e52e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/eldr/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

